### PR TITLE
fix: added class-transformer and class-validator as peer-dependencies

### DIFF
--- a/.changeset/loud-trains-complain.md
+++ b/.changeset/loud-trains-complain.md
@@ -1,0 +1,5 @@
+---
+'@hahnpro/flow-sdk': patch
+---
+
+Added class-validator and class-transformer as peer-dependencies to fix failing tests caused by class-transformer not being installed automatically

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -56,6 +56,10 @@
     "jest": "^27.4.7",
     "typescript": "^4.5.4"
   },
+  "peerDependencies": {
+    "class-transformer": ">=0.4.1",
+    "class-validator": ">=0.13.0"
+  },
   "engines": {
     "node": "^14.13.1 || >=16.0.0"
   }


### PR DESCRIPTION
Added class-transformer and class-validator as peer-dependencies. 


class-transformer was not automatically installed when installing the sdk since version 4.20.0. This should fix this.