### PR TITLE
fix(cli): remove usage of deprecated rmdir nodejs api

### DIFF
--- a/.changeset/eleven-fans-arrive.md
+++ b/.changeset/eleven-fans-arrive.md
@@ -1,0 +1,5 @@
+---
+'@hahnpro/flow-cli': patch
+---
+
+Fix cleaning of build directories for Node.js v16 and later

--- a/packages/cli/lib/cli.mjs
+++ b/packages/cli/lib/cli.mjs
@@ -357,7 +357,7 @@ async function generateSchemasForFile(tsPath, jsonPath) {
 async function clean(buildFolder) {
   return new Promise((resolve, reject) => {
     const spinner = getSpinner('Cleaning').start();
-    fs.rmdir(buildFolder, { recursive: true }, (error) => {
+    fs.rm(buildFolder, { recursive: true, force: true }, (error) => {
       if (error) {
         spinner.stop();
         logger.error('Cleaning failed');


### PR DESCRIPTION
Fix cleaning of build directories for Node.js v16 and later by removing usage of deprecated rmdir options

https://nodejs.org/api/fs.html