### PR TITLE
fix(sdk): allow module names to contain scopes, disallow spec. chars

### DIFF
--- a/.changeset/shiny-chairs-relate.md
+++ b/.changeset/shiny-chairs-relate.md
@@ -1,0 +1,5 @@
+---
+'@hahnpro/flow-sdk': patch
+---
+
+Flow Module name validation has been updated. Names must be all lowercase and not contain any special characters except for hyphens. Can optionally start with a scope "@scopename/"

--- a/packages/sdk/lib/FlowModule.ts
+++ b/packages/sdk/lib/FlowModule.ts
@@ -1,9 +1,11 @@
 import { FlowElement } from './FlowElement';
 
 export function FlowModule(metadata: { name: string; declarations: Array<ClassType<FlowElement>> }): ClassDecorator {
-  const fqnRegExp = new RegExp('^([a-zA-Z][a-zA-Z0-9]*[.-])*[a-zA-Z][a-zA-Z0-9]*$');
-  if (!fqnRegExp.test(metadata.name)) {
-    throw new Error(`Flow Module name (${metadata.name}) is not valid`);
+  const validateNameRegExp = new RegExp(/^(@[a-z][a-z0-9-]*\/)?[a-z][a-z0-9-]*$/);
+  if (!validateNameRegExp.test(metadata.name)) {
+    throw new Error(
+      `Flow Module name (${metadata.name}) is not valid. Name must be all lowercase and not contain any special characters except for hyphens. Can optionally start with a scope "@scopename/"`,
+    );
   }
 
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/packages/sdk/test/context.spec.ts
+++ b/packages/sdk/test/context.spec.ts
@@ -9,8 +9,8 @@ describe('Flow Application', () => {
   test('FLOW.CON.1 Simple Flow Application with Long Running Task', (done) => {
     const flow = {
       elements: [
-        { id: 'testTrigger', module: 'test.module', functionFqn: 'test.resource.TestResource', properties: { assetId: '' } },
-        { id: 'testResource', module: 'test.module', functionFqn: 'test.resource.TestResource', properties: { assetId: 'abc' } },
+        { id: 'testTrigger', module: 'test-module', functionFqn: 'test.resource.TestResource', properties: { assetId: '' } },
+        { id: 'testResource', module: 'test-module', functionFqn: 'test.resource.TestResource', properties: { assetId: 'abc' } },
       ],
       connections: [{ id: 'testConnection1', source: 'testTrigger', target: 'testResource' }],
       context: {
@@ -93,8 +93,8 @@ describe('Flow Application', () => {
   test('FLOW.CON.3 string interpolation with flow context properties', (done) => {
     const flow = {
       elements: [
-        { id: 'testTrigger', module: 'test.module', functionFqn: 'test.resource.TestResource', properties: { assetId: '' } },
-        { id: 'testResource', module: 'test.module', functionFqn: 'test.resource.TestResource', properties: { assetId: '${test}' } },
+        { id: 'testTrigger', module: 'test-module', functionFqn: 'test.resource.TestResource', properties: { assetId: '' } },
+        { id: 'testResource', module: 'test-module', functionFqn: 'test.resource.TestResource', properties: { assetId: '${test}' } },
       ],
       connections: [{ id: 'testConnection1', source: 'testTrigger', target: 'testResource' }],
       context: { flowId: 'testFlow', deploymentId: 'testDeployment' },
@@ -151,7 +151,7 @@ class Properties {
 }
 
 @FlowModule({
-  name: 'test.module',
+  name: 'test-module',
   declarations: [TestResource],
 })
 class TestModule {}

--- a/packages/sdk/test/flow.spec.ts
+++ b/packages/sdk/test/flow.spec.ts
@@ -25,9 +25,9 @@ describe('Flow Application', () => {
     const size = 8;
     const flow = {
       elements: [
-        { id: 'testTrigger', module: 'test.module', functionFqn: 'test.resource.TestResource' },
-        { id: 'testResource', module: 'test.module', functionFqn: 'test.resource.TestResource' },
-        { id: 'longRunningTask', module: 'test.module', functionFqn: 'test.task.LongRunningTask', properties: { delay: 500 } },
+        { id: 'testTrigger', module: 'test-module', functionFqn: 'test.resource.TestResource' },
+        { id: 'testResource', module: 'test-module', functionFqn: 'test.resource.TestResource' },
+        { id: 'longRunningTask', module: 'test-module', functionFqn: 'test.task.LongRunningTask', properties: { delay: 500 } },
       ],
       connections: [
         { id: 'testConnection1', source: 'testTrigger', target: 'testResource' },
@@ -73,8 +73,8 @@ describe('Flow Application', () => {
   it('FLOW.FA.2 should handle invalid stream handlers', async () => {
     const flow = {
       elements: [
-        { id: 'testTrigger', module: 'test.module', functionFqn: 'test.resource.TestResource' },
-        { id: 'testResource', module: 'test.module', functionFqn: 'test.resource.TestResource' },
+        { id: 'testTrigger', module: 'test-module', functionFqn: 'test.resource.TestResource' },
+        { id: 'testResource', module: 'test-module', functionFqn: 'test.resource.TestResource' },
       ],
       connections: [{ id: 'testConnection1', source: 'testTrigger', target: 'testResource', targetStream: 'does-not-exist' }],
       context: {
@@ -97,7 +97,7 @@ describe('Flow Application', () => {
 
   it('FLOW.FA.3 should handle invalid function FQNs', async () => {
     const flow = {
-      elements: [{ id: 'testTrigger', module: 'test.module', functionFqn: 'test.resource.Test123' }],
+      elements: [{ id: 'testTrigger', module: 'test-module', functionFqn: 'test.resource.Test123' }],
       connections: [],
       context: {
         flowId: 'testFlow',
@@ -110,7 +110,7 @@ describe('Flow Application', () => {
     expect(loggerMock.warn).toHaveBeenCalledTimes(0);
     expect(loggerMock.error).toHaveBeenCalledTimes(1);
     expect(loggerMock.error).toHaveBeenLastCalledWith(
-      new Error('Could not create FlowElement for test.module.test.resource.Test123'),
+      new Error('Could not create FlowElement for test-module.test.resource.Test123'),
       expect.objectContaining(flow.context),
     );
 
@@ -118,7 +118,7 @@ describe('Flow Application', () => {
   });
   it('FLOW.FA.4 should handle invalid connection targets', async () => {
     const flow = {
-      elements: [{ id: 'testTrigger', module: 'test.module', functionFqn: 'test.resource.TestResource' }],
+      elements: [{ id: 'testTrigger', module: 'test-module', functionFqn: 'test.resource.TestResource' }],
       connections: [{ id: 'testConnection1', source: 'testTrigger', target: 'testResource' }],
       context: {
         flowId: 'testFlow',
@@ -141,7 +141,7 @@ describe('Flow Application', () => {
 
   it('FLOW.FA.5 should handle invalid flow modules', async () => {
     const flow = {
-      elements: [{ id: 'testTrigger', module: 'test.module', functionFqn: 'test.resource.TestResource' }],
+      elements: [{ id: 'testTrigger', module: 'test-module', functionFqn: 'test.resource.TestResource' }],
       connections: [{ id: 'testConnection1', source: 'testTrigger', target: 'testResource' }],
       context: {
         flowId: 'testFlow',
@@ -164,7 +164,7 @@ describe('Flow Application', () => {
 
   it('FLOW.FA.6 should handle invalid flow functions', async () => {
     const flow = {
-      elements: [{ id: 'testTrigger', module: 'test.module', functionFqn: 'test.resource.TestResource' }],
+      elements: [{ id: 'testTrigger', module: 'test-module', functionFqn: 'test.resource.TestResource' }],
       connections: [{ id: 'testConnection1', source: 'testTrigger', target: 'testResource' }],
       context: {
         flowId: 'testFlow',
@@ -188,8 +188,8 @@ describe('Flow Application', () => {
   it('FLOW.FA.7 should warn if high event loop utilization is detected', (done) => {
     const flow = {
       elements: [
-        { id: 'testTrigger', module: 'test.module', functionFqn: 'test.resource.TestResource' },
-        { id: 'highEluTask', module: 'test.module', functionFqn: 'test.task.HighEluTask', properties: { n: 500_000_000 } },
+        { id: 'testTrigger', module: 'test-module', functionFqn: 'test.resource.TestResource' },
+        { id: 'highEluTask', module: 'test-module', functionFqn: 'test.task.HighEluTask', properties: { n: 500_000_000 } },
       ],
       connections: [{ id: 'testConnection1', source: 'testTrigger', target: 'highEluTask' }],
       context: {
@@ -220,8 +220,8 @@ describe('Flow Application', () => {
   it('FLOW.FA.8 should warn if event queue size is above threshold', (done) => {
     const flow = {
       elements: [
-        { id: 'testTrigger', module: 'test.module', functionFqn: 'test.resource.TestResource' },
-        { id: 'longRunningTask', module: 'test.module', functionFqn: 'test.task.LongRunningTask', properties: { delay: 300 } },
+        { id: 'testTrigger', module: 'test-module', functionFqn: 'test.resource.TestResource' },
+        { id: 'longRunningTask', module: 'test-module', functionFqn: 'test.task.LongRunningTask', properties: { delay: 300 } },
       ],
       connections: [{ id: 'testConnection', source: 'testTrigger', target: 'longRunningTask' }],
       context: { flowId: 'testFlow', deploymentId: 'testDeployment' },
@@ -267,10 +267,10 @@ describe('Flow Application', () => {
   it('FLOW.FA.9 test complex properties', (done) => {
     const flow = {
       elements: [
-        { id: 'testTrigger', module: 'test.module', functionFqn: 'test.resource.TestResource' },
+        { id: 'testTrigger', module: 'test-module', functionFqn: 'test.resource.TestResource' },
         {
           id: 'complex',
-          module: 'test.module',
+          module: 'test-module',
           functionFqn: 'test.resource.ComplexProperties',
           properties: {
             variables: [
@@ -394,7 +394,7 @@ class HighEluProperties {
 }
 
 @FlowModule({
-  name: 'test.module',
+  name: 'test-module',
   declarations: [HighEluTask, LongRunningTask, TestResource, TestComplexProperties],
 })
 class TestModule {}
@@ -402,7 +402,7 @@ class TestModule {}
 class FakeTask {}
 
 @FlowModule({
-  name: 'test.module2',
+  name: 'test-module2',
   declarations: [FakeTask as any],
 })
 class TestModule2 {}

--- a/packages/sdk/test/input-stream.decorator.spec.ts
+++ b/packages/sdk/test/input-stream.decorator.spec.ts
@@ -34,8 +34,8 @@ describe('InputStreamDecorator', () => {
   test('FLOW.ISD.4 should return input event data in a flow', (done) => {
     const flow = {
       elements: [
-        { id: 'testTrigger', module: 'test.module', functionFqn: 'test.resource.TestResource' },
-        { id: 'testResource', module: 'test.module', functionFqn: 'test.resource.TestResource' },
+        { id: 'testTrigger', module: 'test-module', functionFqn: 'test.resource.TestResource' },
+        { id: 'testResource', module: 'test-module', functionFqn: 'test.resource.TestResource' },
       ],
       connections: [{ id: 'testConnection1', source: 'testTrigger', target: 'testResource' }],
     };
@@ -56,8 +56,8 @@ describe('InputStreamDecorator', () => {
   test('FLOW.ISD.5 should only log partial events', (done) => {
     const flow = {
       elements: [
-        { id: 'testTrigger', module: 'test.module', functionFqn: 'test.resource.TestResource' },
-        { id: 'testResource', module: 'test.module', functionFqn: 'test.resource.TestResource' },
+        { id: 'testTrigger', module: 'test-module', functionFqn: 'test.resource.TestResource' },
+        { id: 'testResource', module: 'test-module', functionFqn: 'test.resource.TestResource' },
       ],
       connections: [{ id: 'testConnection1', source: 'testTrigger', target: 'testResource' }],
     };
@@ -87,10 +87,10 @@ describe('InputStreamDecorator', () => {
   test('FLOW.ISD.6 stopPropagation should work in a mixed flow', (done) => {
     const flow = {
       elements: [
-        { id: 'testTrigger', module: 'test.module', functionFqn: 'test.resource.TestResource' },
-        { id: 'testTask1', module: 'test.module', functionFqn: 'test.task.task1' },
-        { id: 'testTask2', module: 'test.module', functionFqn: 'test.task.task2' },
-        { id: 'testRessource', module: 'test.module', functionFqn: 'test.resource.TestResource' },
+        { id: 'testTrigger', module: 'test-module', functionFqn: 'test.resource.TestResource' },
+        { id: 'testTask1', module: 'test-module', functionFqn: 'test.task.task1' },
+        { id: 'testTask2', module: 'test-module', functionFqn: 'test.task.task2' },
+        { id: 'testRessource', module: 'test-module', functionFqn: 'test.resource.TestResource' },
       ],
       connections: [
         { id: 'c1', source: 'testTrigger', target: 'testTask1' },
@@ -150,8 +150,8 @@ describe('InputStreamDecorator', () => {
   test('FLOW.ISD.10 test single function with multiple streams with different configs', (done) => {
     const flow = {
       elements: [
-        { id: 'testTrigger', module: 'test.module', functionFqn: 'test.resource.TestResource' },
-        { id: 'testTask1', module: 'test.module', functionFqn: 'test.task.multi' },
+        { id: 'testTrigger', module: 'test-module', functionFqn: 'test.resource.TestResource' },
+        { id: 'testTask1', module: 'test-module', functionFqn: 'test.task.multi' },
       ],
       connections: [
         { id: 'c1', source: 'testTrigger', target: 'testTask1', targetStream: 'default' },
@@ -202,8 +202,8 @@ describe('InputStreamDecorator', () => {
   test('FLOW.ISD.12 stateful function should work in flow', (done) => {
     const flow = {
       elements: [
-        { id: 'testTrigger', module: 'test.module', functionFqn: 'test.resource.TestResource' },
-        { id: 'stateful', module: 'test.module', functionFqn: 'test.task.stateful' },
+        { id: 'testTrigger', module: 'test-module', functionFqn: 'test.resource.TestResource' },
+        { id: 'stateful', module: 'test-module', functionFqn: 'test.task.stateful' },
       ],
       connections: [{ id: 'c1', source: 'testTrigger', target: 'stateful' }],
     };
@@ -333,7 +333,7 @@ class Deprecated extends FlowTask {
 }
 
 @FlowModule({
-  name: 'test.module',
+  name: 'test-module',
   declarations: [TestResource, TestResourceNoProp, TestTask1, TestTask2, MultiStream, Stateful],
 })
 class TestModule {}

--- a/packages/sdk/test/long-running-rpc.spec.ts
+++ b/packages/sdk/test/long-running-rpc.spec.ts
@@ -7,7 +7,7 @@ describe('Flow RPC long running task', () => {
 
   beforeAll(async () => {
     const flow = {
-      elements: [{ id: 'testResource', module: 'test.module', functionFqn: 'test.resource.TestResource' }],
+      elements: [{ id: 'testResource', module: 'test-module', functionFqn: 'test.resource.TestResource' }],
       connections: [{ id: 'testConnection1', source: 'testTrigger', sourceStream: 'a', target: 'testResource', targetStream: 'a' }],
       context: {
         flowId: 'testFlow',
@@ -48,7 +48,7 @@ class TestResource extends FlowResource {
 }
 
 @FlowModule({
-  name: 'test.module',
+  name: 'test-module',
   declarations: [TestResource],
 })
 class TestModule {}

--- a/packages/sdk/test/message.spec.ts
+++ b/packages/sdk/test/message.spec.ts
@@ -7,8 +7,8 @@ describe('Flow SDK', () => {
   test('FLOW.SDK.1 publish message', (done) => {
     const flow = {
       elements: [
-        { id: 'testTrigger', module: 'test.module', functionFqn: 'test.resource.TestResource' },
-        { id: 'testResource', module: 'test.module', functionFqn: 'test.resource.TestResource' },
+        { id: 'testTrigger', module: 'test-module', functionFqn: 'test.resource.TestResource' },
+        { id: 'testResource', module: 'test-module', functionFqn: 'test.resource.TestResource' },
       ],
       connections: [{ id: 'testConnection1', source: 'testTrigger', target: 'testResource' }],
       context: {
@@ -47,7 +47,7 @@ class TestResource extends FlowResource {
 }
 
 @FlowModule({
-  name: 'test.module',
+  name: 'test-module',
   declarations: [TestResource],
 })
 class TestModule {}

--- a/packages/sdk/test/rpc.spec.ts
+++ b/packages/sdk/test/rpc.spec.ts
@@ -9,7 +9,7 @@ describe('Flow RPC', () => {
 
   beforeAll(async () => {
     const flow = {
-      elements: [{ id: 'testResource', module: 'test.module', functionFqn: 'test.resource.TestResource' }],
+      elements: [{ id: 'testResource', module: 'test-module', functionFqn: 'test.resource.TestResource' }],
       connections: [
         { id: 'testConnection1', source: 'testTrigger', sourceStream: 'a', target: 'testResource', targetStream: 'a' },
         { id: 'testConnection1', source: 'testTrigger', sourceStream: 'b', target: 'testResource', targetStream: 'b' },
@@ -135,7 +135,7 @@ class TestResource extends FlowResource {
 }
 
 @FlowModule({
-  name: 'test.module',
+  name: 'test-module',
   declarations: [TestResource],
 })
 class TestModule {}

--- a/packages/sdk/test/rx.spec.ts
+++ b/packages/sdk/test/rx.spec.ts
@@ -9,10 +9,10 @@ describe('rx', () => {
     const size = 3;
     const flow = {
       elements: [
-        { id: 'testTrigger', module: 'test.module', functionFqn: 'test.resource.TestResource1' },
-        { id: 'testResource1', module: 'test.module', functionFqn: 'test.resource.TestResource1' },
-        { id: 'testResource2', module: 'test.module', functionFqn: 'test.resource.TestResource2' },
-        { id: 'tap', module: 'test.module', functionFqn: 'operators.tap' },
+        { id: 'testTrigger', module: 'test-module', functionFqn: 'test.resource.TestResource1' },
+        { id: 'testResource1', module: 'test-module', functionFqn: 'test.resource.TestResource1' },
+        { id: 'testResource2', module: 'test-module', functionFqn: 'test.resource.TestResource2' },
+        { id: 'tap', module: 'test-module', functionFqn: 'operators.tap' },
       ],
       connections: [
         { id: 'testConnection1', source: 'testTrigger', target: 'testResource1' },
@@ -85,7 +85,7 @@ class TestResource2 extends FlowResource {
 }
 
 @FlowModule({
-  name: 'test.module',
+  name: 'test-module',
   declarations: [TestResource, TestResource2, Tap],
 })
 class TestModule {}


### PR DESCRIPTION
Flow Module name validation has been updated.
Names must be all lowercase and not contain any special characters except for hyphens. Can optionally start with a scope "@scopename/"