### PR TITLE
feat(sdk): publish flow lifecycle events to allow duration tracking

### DIFF
--- a/.changeset/clean-maps-vanish.md
+++ b/.changeset/clean-maps-vanish.md
@@ -1,0 +1,5 @@
+---
+'@hahnpro/flow-sdk': minor
+---
+
+Publish Flow lifecycle events to allow execution duration tracking for elements

--- a/packages/sdk/lib/FlowElement.ts
+++ b/packages/sdk/lib/FlowElement.ts
@@ -54,6 +54,8 @@ export abstract class FlowElement<T = any> {
     this.setProperties(properties);
   };
 
+  public getMetadata = () => this.metadata;
+
   protected setProperties = (properties: T): void => {
     if (this.propertiesClassType) {
       this.properties = this.validateProperties(this.propertiesClassType, properties, this.whitelist);
@@ -156,7 +158,12 @@ export function InputStream(id = 'default', options?: { concurrent?: number; sto
       // add input stream to data to later determine if data should be propagated
       return method.call(
         this,
-        new FlowEvent({ ...event.getMetadata(), inputStreamId: id }, event.getData(), event.getType(), new Date(event.getTime())),
+        new FlowEvent(
+          { id: event.getMetadata().elementId, ...event.getMetadata(), inputStreamId: id },
+          event.getData(),
+          event.getType(),
+          new Date(event.getTime()),
+        ),
       );
     };
   };

--- a/packages/sdk/lib/FlowEvent.ts
+++ b/packages/sdk/lib/FlowEvent.ts
@@ -5,7 +5,7 @@ import { FlowElementContext } from './flow.interface';
 
 export class FlowEvent {
   private event: CloudEvent;
-  private metadata;
+  private metadata: { deploymentId: string; elementId: string; flowId: string; functionFqn: string; inputStreamId: string };
 
   constructor(metadata: FlowElementContext, data: any, outputId = 'default', time = new Date(), dataType?: string) {
     const { id: elementId, deploymentId, flowId, functionFqn, inputStreamId } = metadata;

--- a/packages/sdk/lib/RpcClient.ts
+++ b/packages/sdk/lib/RpcClient.ts
@@ -1,6 +1,6 @@
 import { ChannelWrapper } from 'amqp-connection-manager';
 import { ConsumeMessage } from 'amqplib';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 import { AmqpConnection } from './amqp';
 
 export class RpcClient {

--- a/packages/sdk/lib/flow.interface.ts
+++ b/packages/sdk/lib/flow.interface.ts
@@ -45,3 +45,9 @@ export interface StreamOptions {
 }
 
 export type ClassType<T> = new (...args: any[]) => T;
+
+export enum LifecycleEvent {
+  ACTIVATED = 'com.hahnpro.flow_function.activated',
+  COMPLETED = 'com.hahnpro.flow_function.completed',
+  TERMINATED = 'com.hahnpro.flow_function.terminated',
+}

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -41,8 +41,7 @@
     "python-shell": "^3.0.1",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.5.5",
-    "string-interp": "^0.3.6",
-    "uuid": "^8.3.2"
+    "string-interp": "^0.3.6"
   },
   "devDependencies": {
     "@golevelup/nestjs-rabbitmq": "^2.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,7 +195,6 @@ importers:
       rxjs: ^7.5.5
       string-interp: ^0.3.6
       typescript: ^4.7.3
-      uuid: ^8.3.2
     dependencies:
       '@hahnpro/hpc-api': link:../api
       amqp-connection-manager: 3.9.0_amqplib@0.10.0
@@ -209,7 +208,6 @@ importers:
       reflect-metadata: 0.1.13
       rxjs: 7.5.5
       string-interp: 0.3.6
-      uuid: 8.3.2
     devDependencies:
       '@golevelup/nestjs-rabbitmq': 2.4.0_ubvf3zpnfxbng4ysgp4z2vcq64
       '@nestjs/common': 8.4.6_kgmvgmqc4iohdboj3f7yqhrie4
@@ -5371,7 +5369,7 @@ packages:
       string_decoder: 0.10.31
 
   /readable-stream/1.1.14:
-    resolution: {integrity: sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==}
+    resolution: {integrity: sha1-fPTFTvZI44EwhMY23SB54WbAgdk=}
     dependencies:
       core-util-is: 1.0.3
       inherits: 2.0.4
@@ -5473,7 +5471,7 @@ packages:
     dev: true
 
   /requires-port/1.0.0:
-    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+    resolution: {integrity: sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=}
 
   /resolve-cwd/3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
@@ -5914,7 +5912,7 @@ packages:
     dev: true
 
   /text-table/0.2.0:
-    resolution: {integrity: sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=}
+    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
     dev: true
 
   /thingtalk-units/0.2.1:
@@ -5943,7 +5941,7 @@ packages:
     dev: true
 
   /to-fast-properties/2.0.0:
-    resolution: {integrity: sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=}
+    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
     dev: true
 
@@ -6000,7 +5998,7 @@ packages:
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 28.1.1_@types+node@16.11.39
+      jest: 28.1.1_sxvwizcnvn4mgz6mpodobsoami
       jest-util: 28.1.0
       json5: 2.2.1
       lodash.memoize: 4.1.2


### PR DESCRIPTION

Publish ACTIVATED, COMPLETED and TERMINATED Flow lifecycle events to allow (among other things) duration tracking for Flow Elements