### PR TITLE
feat: use client_secret_jwt as auth method for service accounts

### DIFF
--- a/.changeset/twenty-lizards-add.md
+++ b/.changeset/twenty-lizards-add.md
@@ -1,0 +1,6 @@
+---
+'@hahnpro/hpc-api': minor
+'@hahnpro/flow-cli': minor
+---
+
+Use the more secure client_secret_jwt authentication method for authenticating service accounts against the HPC API

--- a/packages/api/lib/http.service.ts
+++ b/packages/api/lib/http.service.ts
@@ -96,7 +96,7 @@ export class HttpClient {
       });
     }
     if (!this.tokenSet || this.tokenSet.expired() || this.tokenSet.expires_at < Date.now() / 1000 + TOKEN_EXPIRATION_BUFFER) {
-      this.tokenSet = await this.client.grant({ grant_type: 'client_credetials' });
+      this.tokenSet = await this.client.grant({ grant_type: 'client_credentials' });
     }
     return this.tokenSet.access_token;
   };

--- a/packages/api/lib/http.service.ts
+++ b/packages/api/lib/http.service.ts
@@ -1,18 +1,17 @@
 import axios, { AxiosInstance, AxiosRequestConfig, Method } from 'axios';
 import EventSource from 'eventsource';
+import { BaseClient, Issuer, TokenSet } from 'openid-client';
 
 import { Queue } from './Queue';
 import { randomUUID } from 'crypto';
 
-const EXPIRATION_BUFFER = 30 * 1000;
+const TOKEN_EXPIRATION_BUFFER = 30; // 30 seconds
 
 export class HttpClient {
   private readonly axiosInstance: AxiosInstance;
-  private readonly authAxiosInstance: AxiosInstance;
   private readonly requestQueue: Queue;
-
-  private accessToken: string;
-  private accessTokenExpiration = 0;
+  private client: BaseClient;
+  private tokenSet: TokenSet;
 
   public eventSourcesMap: Map<
     string,
@@ -20,14 +19,13 @@ export class HttpClient {
   > = new Map();
 
   constructor(
-    private baseURL: string,
-    authbaseURL: string,
+    private readonly baseURL: string,
+    private readonly authbaseURL: string,
     private readonly realm: string,
-    private readonly client: string,
-    private readonly secret: string,
+    private readonly clientId: string,
+    private readonly clientSecret: string,
   ) {
     this.axiosInstance = axios.create({ baseURL, timeout: 60000 });
-    this.authAxiosInstance = axios.create({ baseURL: authbaseURL || baseURL, timeout: 10000 });
     this.requestQueue = new Queue({ concurrency: 1, timeout: 70000, throwOnTimeout: true });
   }
 
@@ -88,42 +86,18 @@ export class HttpClient {
     }
   }
 
-  public getAccessToken = (): Promise<string> => {
-    if (this.isTokenValid()) {
-      return Promise.resolve(this.accessToken);
-    } else {
-      return this.getToken();
+  public getAccessToken = async (): Promise<string> => {
+    if (!this.client?.issuer) {
+      const authIssuer = await Issuer.discover(`${this.authbaseURL}/auth/realms/${this.realm}/`);
+      this.client = await new authIssuer.Client({
+        client_id: this.clientId,
+        client_secret: this.clientSecret,
+        token_endpoint_auth_method: 'client_secret_jwt',
+      });
     }
-  };
-
-  private isTokenValid = (): boolean => {
-    if (this.accessToken && this.accessTokenExpiration) {
-      return Date.now() + EXPIRATION_BUFFER < this.accessTokenExpiration;
+    if (!this.tokenSet || this.tokenSet.expired() || this.tokenSet.expires_at < Date.now() / 1000 + TOKEN_EXPIRATION_BUFFER) {
+      this.tokenSet = await this.client.grant({ grant_type: 'client_credetials' });
     }
-    return false;
-  };
-
-  private getToken = (): Promise<string> => {
-    return new Promise<string>((resolve, reject) => {
-      const params = new URLSearchParams([
-        ['client_id', this.client],
-        ['client_secret', this.secret],
-        ['grant_type', 'client_credentials'],
-      ]);
-      const headers = { 'Content-Type': 'application/x-www-form-urlencoded' };
-
-      this.authAxiosInstance
-        .post<any>(`/realms/${this.realm}/protocol/openid-connect/token`, params.toString(), { headers })
-        .then((res) => {
-          if (res?.data?.access_token && res.data.expires_in) {
-            this.accessToken = res.data.access_token;
-            this.accessTokenExpiration = Date.now() + res.data.expires_in * 1000;
-            return resolve(res.data.access_token);
-          } else {
-            throw new Error('Invalid access token received');
-          }
-        })
-        .catch(reject);
-    });
+    return this.tokenSet.access_token;
   };
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -33,12 +33,14 @@
     "eventsource": "^2.0.2",
     "form-data": "^4.0.0",
     "jwt-decode": "^3.1.2",
+    "openid-client": "^5.1.8",
     "p-queue": "^6.6.2",
     "ts-mixer": "^6.0.1"
   },
   "devDependencies": {
     "@types/eventsource": "^1.1.9",
-    "axios-mock-adapter": "^1.21.1"
+    "axios-mock-adapter": "^1.21.1",
+    "nock": "^13.2.9"
   },
   "engines": {
     "node": ">=v14.13"

--- a/packages/api/test/http.service.spec.ts
+++ b/packages/api/test/http.service.spec.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
+import nock from 'nock';
 
 import { HttpClient } from '../lib';
 
@@ -11,10 +12,15 @@ describe('HTTP Service', () => {
     axiosMock = new MockAdapter(axios, { delayResponse: 100 });
     axiosMock.onGet('/api/assets').reply(200, { docs: assets });
     axiosMock.onGet(/\/api\/assets\/*/).reply(200, assets[0]);
-    axiosMock.onPost(/\/auth\/*/).reply(200, {
-      access_token: 'TOKEN',
-      expires_in: 60000,
-    });
+
+    nock('https://test.com')
+      .get('/auth/realms/test/.well-known/openid-configuration')
+      .reply(200, {
+        issuer: 'https://test.com/auth/realms/test',
+        authorization_endpoint: 'https://test.com/auth/realms/test/protocol/openid-connect/auth',
+        token_endpoint: 'https://test.com/auth/realms/test/protocol/openid-connect/token',
+        token_endpoint_auth_signing_alg_values_supported: ['HS256', 'HS512'],
+      });
   });
 
   afterEach(() => {
@@ -22,7 +28,8 @@ describe('HTTP Service', () => {
   });
 
   it('FLOW.HS.1 should queue requests', async () => {
-    const client = new HttpClient('/api', '/auth', 'test', 'test', 'test');
+    nock('https://test.com').post('/auth/realms/test/protocol/openid-connect/token').reply(200, { access_token: 'TOKEN' });
+    const client = new HttpClient('/api', 'https://test.com', 'test', 'test', 'test');
 
     expect(client.getQueueStats().total).toBe(0);
     const response = await client.get<any>('/assets');
@@ -39,45 +46,44 @@ describe('HTTP Service', () => {
     expect(client.getQueueStats()).toEqual({ peak: assets.length - 1, pending: 0, size: 0, total: assets.length + 1 });
   });
 
-  it('FLOW.HS.2 should handle invalid access token', async () => {
-    axiosMock.onPost(/\/auth\/*/).reply(200, {});
-    const client = new HttpClient('/api', '/auth', 'test', 'test', 'test');
-    await expect(client.get<any>('/assets')).rejects.toThrow('Invalid access token received');
-  });
-
   it('FLOW.HS.3 should handle auth network errors', async () => {
-    axiosMock.onPost(/\/auth\/*/).networkError();
-    const client = new HttpClient('/api', '/auth', 'test', 'test', 'test');
+    nock('https://test.com').post('/auth/realms/test/protocol/openid-connect/token').replyWithError(new Error('Network Error'));
+    const client = new HttpClient('/api', 'https://test.com', 'test', 'test', 'test');
     await expect(client.get<any>('/assets')).rejects.toThrow('Network Error');
   });
 
   it('FLOW.HS.4 should handle auth timeouts', async () => {
-    axiosMock.onPost(/\/auth\/*/).timeout();
-    const client = new HttpClient('/api', '/auth', 'test', 'test', 'test');
+    nock('https://test.com')
+      .post('/auth/realms/test/protocol/openid-connect/token')
+      .replyWithError(new Error('timeout of 10000ms exceeded'));
+    const client = new HttpClient('/api', 'https://test.com', 'test', 'test', 'test');
     await expect(client.get<any>('/assets')).rejects.toThrow('timeout of 10000ms exceeded');
   });
 
   it('FLOW.HS.5 should handle aborted auth requests', async () => {
-    axiosMock.onPost(/\/auth\/*/).abortRequest();
-    const client = new HttpClient('/api', '/auth', 'test', 'test', 'test');
+    nock('https://test.com').post('/auth/realms/test/protocol/openid-connect/token').replyWithError(new Error('Request aborted'));
+    const client = new HttpClient('/api', 'https://test.com', 'test', 'test', 'test');
     await expect(client.get<any>('/assets')).rejects.toThrow('Request aborted');
   });
 
   it('FLOW.HS.6 should handle network errors', async () => {
+    nock('https://test.com').post('/auth/realms/test/protocol/openid-connect/token').reply(200, { access_token: 'TOKEN' });
     axiosMock.onGet('/api/assets').networkError();
-    const client = new HttpClient('/api', '/auth', 'test', 'test', 'test');
+    const client = new HttpClient('/api', 'https://test.com', 'test', 'test', 'test');
     await expect(client.get<any>('/assets')).rejects.toThrow('Network Error');
   });
 
   it('FLOW.HS.7 should handle timeouts', async () => {
+    nock('https://test.com').post('/auth/realms/test/protocol/openid-connect/token').reply(200, { access_token: 'TOKEN' });
     axiosMock.onGet('/api/assets').timeout();
-    const client = new HttpClient('/api', '/auth', 'test', 'test', 'test');
+    const client = new HttpClient('/api', 'https://test.com', 'test', 'test', 'test');
     await expect(client.get<any>('/assets')).rejects.toThrow('timeout of 60000ms exceeded');
   });
 
   it('FLOW.HS.8 should handle aborted requests', async () => {
+    nock('https://test.com').post('/auth/realms/test/protocol/openid-connect/token').reply(200, { access_token: 'TOKEN' });
     axiosMock.onGet('/api/assets').abortRequest();
-    const client = new HttpClient('/api', '/auth', 'test', 'test', 'test');
+    const client = new HttpClient('/api', 'https://test.com', 'test', 'test', 'test');
     await expect(client.get<any>('/assets')).rejects.toThrow('Request aborted');
   });
 });

--- a/packages/cli/lib/auth.mjs
+++ b/packages/cli/lib/auth.mjs
@@ -43,15 +43,19 @@ export async function getAccessToken(baseUrl = BASE_URL, realm = REALM) {
       ? new Promise(async (resolve, reject) => {
           try {
             const kcIssuer = await openidClient.Issuer.discover(`${baseUrl}/auth/realms/${realm}/`);
-            const client = new kcIssuer.Client({ client_id: CLIENT_ID, client_secret: CLIENT_SECRET });
-            const tokenSet1 = await client.grant({ grant_type: 'client_credentials' });
+            const client = new kcIssuer.Client({
+              client_id: CLIENT_ID,
+              client_secret: CLIENT_SECRET,
+              token_endpoint_auth_method: 'client_secret_jwt',
+            });
+            tokenSet = await client.grant({ grant_type: 'client_credentials' });
 
-            nconf.set(baseUrl.replace(/:/g, ''), tokenSet1);
+            nconf.set(baseUrl.replace(/:/g, ''), tokenSet);
             nconf.save((error) => {
               if (error) {
                 logger.error(error);
               }
-              return resolve(tokenSet1.access_token);
+              return resolve(tokenSet.access_token);
             });
           } catch (error) {
             return reject(error);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,8 @@ importers:
       eventsource: ^2.0.2
       form-data: ^4.0.0
       jwt-decode: ^3.1.2
+      nock: ^13.2.9
+      openid-client: ^5.1.8
       p-queue: ^6.6.2
       ts-mixer: ^6.0.1
     dependencies:
@@ -100,11 +102,13 @@ importers:
       eventsource: 2.0.2
       form-data: 4.0.0
       jwt-decode: 3.1.2
+      openid-client: 5.1.8
       p-queue: 6.6.2
       ts-mixer: 6.0.1
     devDependencies:
       '@types/eventsource': 1.1.9
       axios-mock-adapter: 1.21.1_axios@0.27.2
+      nock: 13.2.9
 
   packages/cli:
     specifiers:
@@ -4214,6 +4218,10 @@ packages:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
 
+  /json-stringify-safe/5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+    dev: true
+
   /json5/2.2.1:
     resolution: {integrity: sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==}
     engines: {node: '>=6'}
@@ -4521,6 +4529,18 @@ packages:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
     dev: false
+
+  /nock/13.2.9:
+    resolution: {integrity: sha512-1+XfJNYF1cjGB+TKMWi29eZ0b82QOvQs2YoLNzbpWGqFMtRQHTa57osqdGj4FrFPgkO4D4AZinzUJR9VvW3QUA==}
+    engines: {node: '>= 10.13'}
+    dependencies:
+      debug: 4.3.4
+      json-stringify-safe: 5.0.1
+      lodash: 4.17.21
+      propagate: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /node-fetch/2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
@@ -4941,6 +4961,11 @@ packages:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
+    dev: true
+
+  /propagate/2.0.1:
+    resolution: {integrity: sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==}
+    engines: {node: '>= 8'}
     dev: true
 
   /proxy-addr/2.0.7:


### PR DESCRIPTION
updates the http service to use `client_secret_jwt` as the authentication method for improved security

https://datatracker.ietf.org/doc/html/rfc7523#section-2.1