### PR TITLE
fix(sdk): avoid processing and pblishing all logs twice

### DIFF
--- a/.changeset/wicked-clocks-kick.md
+++ b/.changeset/wicked-clocks-kick.md
@@ -1,0 +1,5 @@
+---
+'@hahnpro/flow-sdk': patch
+---
+
+Fixed logging. All logs were processed and published twice.


### PR DESCRIPTION
wrong base logger was used for element context initialization

ref #130 