### PR TITLE
feat(cli): multi-project commands

### DIFF
--- a/.changeset/breezy-moles-swim.md
+++ b/.changeset/breezy-moles-swim.md
@@ -1,0 +1,5 @@
+---
+'@hahnpro/flow-cli': minor
+---
+
+When executing commands like `flow build` or `flow publish-module` multiple Modules can now be specified as a comma-separated list: e.g. `flow build module1,module2`

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Python dependencies
-        run: pip install aio_pika
+        run: pip install "aio-pika==8.2.*"
       - name: Prepare PNPM
         uses: ./.github/actions/prepare-pnpm
       - name: Activate Post Build Hooks


### PR DESCRIPTION

When executing commands like `flow build` or `flow publish-module` multiple Modules can now be specified as a comma-separated list: e.g. `flow build module1,module2`
