### PR TITLE
fix(sdk): allow unknown values for property validation

### DIFF
--- a/.changeset/seven-ears-learn.md
+++ b/.changeset/seven-ears-learn.md
@@ -1,0 +1,5 @@
+---
+'@hahnpro/flow-sdk': patch
+---
+
+Allow unknown values for property validation

--- a/packages/sdk/lib/FlowElement.ts
+++ b/packages/sdk/lib/FlowElement.ts
@@ -89,7 +89,7 @@ export abstract class FlowElement<T = any> {
 
   protected validateProperties<P>(classType: ClassType<P>, properties: any = {}, whitelist = false): P {
     const props: P = plainToInstance<P, any>(classType, properties);
-    const errors = validateSync(props as any, { whitelist });
+    const errors = validateSync(props as any, { forbidUnknownValues: false, whitelist });
     if (Array.isArray(errors) && errors.length > 0) {
       for (const e of errors) {
         this.logValidationErrors(e);


### PR DESCRIPTION

fixes regression introduced by [breaking change](https://github.com/typestack/class-validator/blob/develop/CHANGELOG.md#breaking-changes) in class-validator package