### PR TITLE
fix(api): auth token expiration check

### DIFF
--- a/.changeset/shiny-ducks-count.md
+++ b/.changeset/shiny-ducks-count.md
@@ -1,0 +1,5 @@
+---
+'@hahnpro/hpc-api': patch
+---
+
+Fixed auth token expiration check

--- a/packages/api/lib/http.service.ts
+++ b/packages/api/lib/http.service.ts
@@ -6,8 +6,6 @@ import { Queue } from './Queue';
 import { TokenSet } from './token-set';
 import { stringify } from 'querystring';
 
-const TOKEN_EXPIRATION_BUFFER = 30; // 30 seconds
-
 export class HttpClient {
   private readonly axiosInstance: AxiosInstance;
   private readonly authAxiosInstance: AxiosInstance;
@@ -88,11 +86,11 @@ export class HttpClient {
     }
   }
 
-  public getAccessToken = async (): Promise<string> => {
-    if (!this.tokenSet || this.tokenSet.expired() || this.tokenSet.expiresAt < Date.now() / 1000 + TOKEN_EXPIRATION_BUFFER) {
+  public getAccessToken = async (forceRefresh = false): Promise<string> => {
+    if (forceRefresh || !this.tokenSet || this.tokenSet.isExpired()) {
       return this.requestAccessToken();
     }
-    return this.tokenSet.access_token;
+    return this.tokenSet.accessToken;
   };
 
   private validateIssuer(issuer: Issuer): Issuer {

--- a/packages/api/lib/token-set.ts
+++ b/packages/api/lib/token-set.ts
@@ -1,21 +1,27 @@
+const TOKEN_EXPIRATION_BUFFER = 20; // 20 seconds
+
 export class TokenSet {
-  public expiresAt: number;
-  public access_token: string;
+  private readonly _accessToken: string;
+  private readonly _expiresAt: number;
 
   constructor(access_token: string, expires_in: number) {
-    this.expires_in = expires_in;
-    this.access_token = access_token;
+    this._accessToken = access_token;
+    this._expiresAt = Math.floor(Date.now() / 1000) + Number(expires_in);
   }
 
-  set expires_in(value) {
-    this.expiresAt = Date.now() + Number(value);
+  get accessToken(): string {
+    return this._accessToken;
   }
 
-  get expires_in(): number {
-    return Math.max(this.expiresAt - Date.now(), 0);
+  get expiresAt(): number {
+    return this._expiresAt;
   }
 
-  expired(): boolean {
-    return this.expires_in === 0;
+  get expiresIn(): number {
+    return Math.max(this.expiresAt - Math.ceil(Date.now() / 1000), 0);
+  }
+
+  public isExpired(): boolean {
+    return this.expiresIn <= TOKEN_EXPIRATION_BUFFER;
   }
 }


### PR DESCRIPTION
Fixes auth token expiration check:

`expires_in` of auth token is in seconds but `TokenSet.expired()` compared it to `Date.now()` which is in milliseconds.
This resulted in a token refresh before most API requests
