### PR TITLE
fix(sdk): fixed broken lazy initilaization of RpcClient

### DIFF
--- a/.changeset/forty-flies-decide.md
+++ b/.changeset/forty-flies-decide.md
@@ -1,0 +1,5 @@
+---
+'@hahnpro/flow-sdk': patch
+---
+
+fixed bug that caused complete failure of the RPC mechanism, when multiple functions tried to call a RPC function for the first time at the same time. Bug was fixed by removeing obsolete lazy initialization of RpcClient.

--- a/.changeset/forty-flies-decide.md
+++ b/.changeset/forty-flies-decide.md
@@ -2,4 +2,4 @@
 '@hahnpro/flow-sdk': patch
 ---
 
-fixed bug that caused complete failure of the RPC mechanism, when multiple functions tried to call a RPC function for the first time at the same time. Bug was fixed by removeing obsolete lazy initialization of RpcClient.
+Fixed bug that caused complete failure of the RPC mechanism, when multiple functions tried to call a RPC function for the first time at the same time. Bug was fixed by removing obsolete lazy initialization of RpcClient.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,15 +32,26 @@ jobs:
     strategy:
       matrix:
         node-version: [16.x, 18.x, 19.x]
+    services:
+      rabbitmq:
+        image: rabbitmq:3.11
+        ports:
+          - 5672:5672
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8.x
+      - name: Install Python dependencies
+        run: pip install "aio-pika==9.0.*" numpy
       - name: Prepare PNPM
         uses: ./.github/actions/prepare-pnpm
         with:
           node-version: ${{ matrix.node-version }}
       - name: Test SDK
-        run: pnpm test packages/sdk -- --testPathIgnorePatterns rpc.spec.ts sidrive.spec.ts
+        run: pnpm test packages/sdk -- --forceExit --runInBand --testPathIgnorePatterns sidrive.spec.ts
   test-api:
     name: Test API
     runs-on: ubuntu-latest
@@ -75,7 +86,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Python dependencies
-        run: pip install "aio-pika==8.2.*"
+        run: pip install "aio-pika==9.0.*"
       - name: Prepare PNPM
         uses: ./.github/actions/prepare-pnpm
       - name: Activate Post Build Hooks

--- a/examples/modules/python/README.md
+++ b/examples/modules/python/README.md
@@ -23,8 +23,8 @@ There are two possibilities to run python scripts in your Flow-Functions.
 The RPC client does not implement any custom json serializers for non python types, as this
 would require adding the packages where these types come from as dependencies.
 
-If you want to return non-standard types despite that you, can implement your own json 
-serializer to be used by the RPC client. 
+If you want to return non-standard types despite that you, can implement your own json
+serializer to be used by the RPC client.
 The serializer has to inherit from the builtin class `json.JSONEncoder`. To then make the client use it,
 return it together with your data as a tuple.
 
@@ -42,7 +42,7 @@ class NpEncoder(json.JSONEncoder):
         if isinstance(obj, np.ndarray):
             return obj.tolist()
         return json.JSONEncoder.default(self, obj)
-    
+
 @RemoteProcedure
 def returnsNumpy():
     return np.power(100, 4, dtype=np.int64), NpEncoder

--- a/packages/sdk/lib/FlowApplication.ts
+++ b/packages/sdk/lib/FlowApplication.ts
@@ -119,7 +119,6 @@ export class FlowApplication {
       }
 
       this._rpcClient = new RpcClient(this.amqpConnection);
-      await this._rpcClient.init();
     }
 
     for (const module of this.modules) {

--- a/packages/sdk/lib/FlowApplication.ts
+++ b/packages/sdk/lib/FlowApplication.ts
@@ -37,7 +37,7 @@ export class FlowApplication {
   private outputQueueMetrics = new Map<string, QueueMetrics>();
   private performanceMap = new Map<string, EventLoopUtilization>();
   private properties: Record<string, any>;
-  public rpcClient: RpcClient;
+  private _rpcClient: RpcClient;
 
   private initialized = false;
 
@@ -118,8 +118,8 @@ export class FlowApplication {
         return;
       }
 
-      this.rpcClient = new RpcClient(this.amqpConnection);
-      await this.rpcClient.init();
+      this._rpcClient = new RpcClient(this.amqpConnection);
+      await this._rpcClient.init();
     }
 
     for (const module of this.modules) {
@@ -281,6 +281,8 @@ export class FlowApplication {
 
   public subscribe = (streamId: string, observer: PartialObserver<FlowEvent>) => this.getOutputStream(streamId).subscribe(observer);
 
+  public rpcClient = () => this._rpcClient;
+
   public emit = (event: FlowEvent) => {
     if (event) {
       try {
@@ -417,7 +419,7 @@ export class FlowApplication {
         for (const element of Object.values(this.elements)) {
           element?.onDestroy?.();
         }
-        await this.rpcClient?.close();
+        await this._rpcClient?.close();
       } catch (err) {
         this.logger.error(err);
       }

--- a/packages/sdk/lib/FlowApplication.ts
+++ b/packages/sdk/lib/FlowApplication.ts
@@ -428,7 +428,7 @@ export class FlowApplication {
       /* eslint-disable-next-line no-console */
       console.error(err);
     } finally {
-      if (process.env.JEST_WORKER_ID == undefined || process.env.NODE_ENV !== 'test') {
+      if (process.env.NODE_ENV !== 'test') {
         process.exit(exitCode);
       }
     }

--- a/packages/sdk/lib/FlowElement.ts
+++ b/packages/sdk/lib/FlowElement.ts
@@ -119,10 +119,7 @@ export abstract class FlowElement<T = any> {
   protected interpolate = (value: any, ...templateVariables: any) => fillTemplate(value, ...templateVariables);
 
   protected async callRpcFunction(functionName: string, ...args: any[]) {
-    return this.app
-      ?.rpcClient()
-      .callFunction(this.rpcRoutingKey, functionName, ...args)
-      .catch((err) => this.logger.error(err));
+    return this.app?.rpcClient().callFunction(this.rpcRoutingKey, functionName, ...args);
   }
 
   protected runPyRpcScript(scriptPath: string, ...args: (string | boolean | number)[]) {

--- a/packages/sdk/lib/FlowElement.ts
+++ b/packages/sdk/lib/FlowElement.ts
@@ -119,7 +119,10 @@ export abstract class FlowElement<T = any> {
   protected interpolate = (value: any, ...templateVariables: any) => fillTemplate(value, ...templateVariables);
 
   protected async callRpcFunction(functionName: string, ...args: any[]) {
-    return this.app?.rpcClient.callFunction(this.rpcRoutingKey, functionName, ...args).catch((err) => this.logger.error(err));
+    return this.app
+      ?.rpcClient()
+      .callFunction(this.rpcRoutingKey, functionName, ...args)
+      .catch((err) => this.logger.error(err));
   }
 
   protected runPyRpcScript(scriptPath: string, ...args: (string | boolean | number)[]) {

--- a/packages/sdk/lib/FlowElement.ts
+++ b/packages/sdk/lib/FlowElement.ts
@@ -119,11 +119,7 @@ export abstract class FlowElement<T = any> {
   protected interpolate = (value: any, ...templateVariables: any) => fillTemplate(value, ...templateVariables);
 
   protected async callRpcFunction(functionName: string, ...args: any[]) {
-    try {
-      return this.app?.rpcClient.callFunction(this.rpcRoutingKey, functionName, ...args);
-    } catch (err) {
-      this.logger.error(err);
-    }
+    return this.app?.rpcClient.callFunction(this.rpcRoutingKey, functionName, ...args).catch((err) => this.logger.error(err));
   }
 
   protected runPyRpcScript(scriptPath: string, ...args: (string | boolean | number)[]) {

--- a/packages/sdk/lib/FlowElement.ts
+++ b/packages/sdk/lib/FlowElement.ts
@@ -120,7 +120,7 @@ export abstract class FlowElement<T = any> {
 
   protected async callRpcFunction(functionName: string, ...args: any[]) {
     try {
-      return (await this.app?.rpcClient())?.callFunction(this.rpcRoutingKey, functionName, ...args);
+      return this.app?.rpcClient.callFunction(this.rpcRoutingKey, functionName, ...args);
     } catch (err) {
       this.logger.error(err);
     }

--- a/packages/sdk/lib/RpcClient.ts
+++ b/packages/sdk/lib/RpcClient.ts
@@ -14,10 +14,13 @@ export class RpcClient {
   }
 
   public async init() {
-    this.channel = this.amqpConnection.managedConnection.createChannel({ json: true });
-    await this.channel.waitForConnect();
-    await this.channel.assertExchange('rpc_direct_exchange', 'direct', { durable: false });
-    await this.channel.consume('amq.rabbitmq.reply-to', this.onMessage, { noAck: true });
+    this.channel = this.amqpConnection.managedConnection.createChannel({
+      json: true,
+      setup: async (channel) => {
+        await channel.assertExchange('rpc_direct_exchange', 'direct', { durable: false });
+        await channel.consume('amq.rabbitmq.reply-to', this.onMessage, { noAck: true });
+      },
+    });
   }
 
   private onMessage = (msg: ConsumeMessage) => {

--- a/packages/sdk/lib/RpcClient.ts
+++ b/packages/sdk/lib/RpcClient.ts
@@ -11,9 +11,7 @@ export class RpcClient {
     if (!amqpConnection) {
       throw new Error('currently no amqp connection available');
     }
-  }
 
-  public async init() {
     this.channel = this.amqpConnection.managedConnection.createChannel({
       json: true,
       setup: async (channel) => {

--- a/packages/sdk/test/flow.spec.ts
+++ b/packages/sdk/test/flow.spec.ts
@@ -208,7 +208,7 @@ describe('Flow Application', () => {
 
     flowApp.emit(new FlowEvent({ id: 'testTrigger' }, {}));
     expect(loggerMock.log).toHaveBeenCalledWith('Flow Deployment is running', expect.objectContaining(flow.context));
-  });
+  }, 10000);
 
   it('FLOW.FA.8 should warn if event queue size is above threshold', (done) => {
     const flow = {
@@ -254,7 +254,7 @@ describe('Flow Application', () => {
     }
 
     expect(loggerMock.log).toHaveBeenCalledWith('Flow Deployment is running', expect.objectContaining(flow.context));
-  });
+  }, 10000);
 
   it('FLOW.FA.9 test complex properties', (done) => {
     const flow = {

--- a/packages/sdk/test/flow.spec.ts
+++ b/packages/sdk/test/flow.spec.ts
@@ -5,16 +5,7 @@ import { loggerMock } from './logger.mock';
 import { Type } from 'class-transformer';
 
 describe('Flow Application', () => {
-  let mockExit;
-
-  beforeEach(() => {
-    // ensure process.exit gets called
-    delete process.env.JEST_WORKER_ID;
-    mockExit = jest.spyOn(process, 'exit').mockImplementation();
-  });
-
   afterEach(() => {
-    mockExit.mockClear();
     loggerMock.log.mockReset();
     loggerMock.warn.mockReset();
     loggerMock.error.mockReset();
@@ -65,7 +56,6 @@ describe('Flow Application', () => {
             expect(event.getTime()).toBeDefined();
 
             if (++count === size) {
-              expect(mockExit).not.toHaveBeenCalled();
               resolve();
             }
           } catch (e) {
@@ -104,8 +94,6 @@ describe('Flow Application', () => {
       functionFqn: 'FlowApplication',
       id: 'none',
     });
-
-    expect(mockExit).toHaveBeenCalledWith(1);
   });
 
   it('FLOW.FA.3 should handle invalid function FQNs', async () => {
@@ -126,8 +114,6 @@ describe('Flow Application', () => {
       new Error('Could not create FlowElement for test-module.test.resource.Test123'),
       expect.objectContaining(flow.context),
     );
-
-    expect(mockExit).toHaveBeenCalledWith(1);
   });
 
   it('FLOW.FA.4 should handle invalid connection targets', async () => {
@@ -149,8 +135,6 @@ describe('Flow Application', () => {
       functionFqn: 'FlowApplication',
       id: 'none',
     });
-
-    expect(mockExit).toHaveBeenCalledWith(1);
   });
 
   it('FLOW.FA.5 should handle invalid flow modules', async () => {
@@ -172,8 +156,6 @@ describe('Flow Application', () => {
       functionFqn: 'FlowApplication',
       id: 'none',
     });
-
-    expect(mockExit).toHaveBeenCalledWith(1);
   });
 
   it('FLOW.FA.6 should handle invalid flow functions', async () => {
@@ -195,8 +177,6 @@ describe('Flow Application', () => {
       functionFqn: 'FlowApplication',
       id: 'none',
     });
-
-    expect(mockExit).toHaveBeenCalledWith(1);
   });
 
   it('FLOW.FA.7 should warn if high event loop utilization is detected', (done) => {
@@ -222,7 +202,6 @@ describe('Flow Application', () => {
           expect.stringContaining('High event loop utilization detected for highEluTask.default with event'),
           { ...flow.context, functionFqn: 'FlowApplication', id: 'none' },
         );
-        expect(mockExit).not.toHaveBeenCalled();
         done();
       },
     });
@@ -248,7 +227,6 @@ describe('Flow Application', () => {
         try {
           expect(event.getData()).toEqual({ foo: 'bar' });
           if (++count === 10) {
-            expect(mockExit).not.toHaveBeenCalled();
             expect(loggerMock.warn).toHaveBeenCalledTimes(2);
             expect(loggerMock.warn).toHaveBeenCalledWith('Input stream "longRunningTask.default" has 100 queued events', {
               deploymentId: 'testDeployment',

--- a/packages/sdk/test/input-stream.decorator.spec.ts
+++ b/packages/sdk/test/input-stream.decorator.spec.ts
@@ -65,6 +65,13 @@ describe('InputStreamDecorator', () => {
       createSubscriber: jest.fn(),
       publish: jest.fn(),
       managedChannel: { assertExchange: jest.fn() },
+      managedConnection: {
+        createChannel: () => ({
+          assertExchange: jest.fn(),
+          waitForConnect: jest.fn(),
+          consume: jest.fn(),
+        }),
+      },
     };
     const spyInstance = jest
       .spyOn(amqpConnection, 'publish')

--- a/packages/sdk/test/rpc.spec.ts
+++ b/packages/sdk/test/rpc.spec.ts
@@ -15,12 +15,12 @@ describe('Flow RPC', () => {
       ],
       connections: [
         { id: 'testConnection1', source: 'testTrigger', sourceStream: 'a', target: 'testResource', targetStream: 'a' },
+        { id: 'testConnection2', source: 'testTrigger', sourceStream: 'b', target: 'testResource2', targetStream: 'b' },
         { id: 'testConnection1', source: 'testTrigger', sourceStream: 'b', target: 'testResource', targetStream: 'b' },
         { id: 'testConnection1', source: 'testTrigger', sourceStream: 'c', target: 'testResource', targetStream: 'c' },
         { id: 'testConnection1', source: 'testTrigger', sourceStream: 'd', target: 'testResource', targetStream: 'd' },
         { id: 'testConnection1', source: 'testTrigger', sourceStream: 'e', target: 'testResource', targetStream: 'e' },
         { id: 'testConnection1', source: 'testTrigger', sourceStream: 'f', target: 'testResource', targetStream: 'f' },
-        { id: 'testConnection2', source: 'testTrigger', sourceStream: 'a', target: 'testResource2', targetStream: 'a' },
       ],
       context: {
         flowId: 'testFlow',

--- a/packages/sdk/test/rpc.spec.ts
+++ b/packages/sdk/test/rpc.spec.ts
@@ -32,7 +32,7 @@ describe('Flow RPC', () => {
     await amqpConnection.init();
     flowApp = new FlowApplication([TestModule], flow, null, amqpConnection, true, true);
     await flowApp.init();
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await new Promise((resolve) => setTimeout(resolve, 2000));
   });
 
   test('FLOW.RPC.1 publish message', (done) => {
@@ -62,6 +62,7 @@ describe('Flow RPC', () => {
   test('FLOW.RPC.3 error in remote procedure', (done) => {
     flowApp.subscribe('testResource.c', {
       next: async (event: FlowEvent) => {
+        console.log(event.getData());
         expect(event.getData().err).toBeDefined();
         await flowApp.destroy();
         done();

--- a/packages/sdk/test/rpc.spec.ts
+++ b/packages/sdk/test/rpc.spec.ts
@@ -9,7 +9,10 @@ describe('Flow RPC', () => {
 
   beforeAll(async () => {
     const flow = {
-      elements: [{ id: 'testResource', module: 'test-module', functionFqn: 'test.resource.TestResource' }],
+      elements: [
+        { id: 'testResource', module: 'test-module', functionFqn: 'test.resource.TestResource' },
+        { id: 'testResource2', module: 'test-module', functionFqn: 'test.resource.TestResource' },
+      ],
       connections: [
         { id: 'testConnection1', source: 'testTrigger', sourceStream: 'a', target: 'testResource', targetStream: 'a' },
         { id: 'testConnection1', source: 'testTrigger', sourceStream: 'b', target: 'testResource', targetStream: 'b' },
@@ -17,6 +20,7 @@ describe('Flow RPC', () => {
         { id: 'testConnection1', source: 'testTrigger', sourceStream: 'd', target: 'testResource', targetStream: 'd' },
         { id: 'testConnection1', source: 'testTrigger', sourceStream: 'e', target: 'testResource', targetStream: 'e' },
         { id: 'testConnection1', source: 'testTrigger', sourceStream: 'f', target: 'testResource', targetStream: 'f' },
+        { id: 'testConnection2', source: 'testTrigger', sourceStream: 'a', target: 'testResource2', targetStream: 'a' },
       ],
       context: {
         flowId: 'testFlow',

--- a/packages/sdk/test/validation.spec.ts
+++ b/packages/sdk/test/validation.spec.ts
@@ -5,14 +5,7 @@ import { FlowFunction, FlowTask } from '../lib';
 import { loggerMock } from './logger.mock';
 
 describe('Property Validation', () => {
-  let mockExit;
-
-  beforeEach(() => {
-    mockExit = jest.spyOn(process, 'exit').mockImplementation();
-  });
-
   afterEach(() => {
-    mockExit.mockClear();
     loggerMock.log.mockReset();
     loggerMock.warn.mockReset();
     loggerMock.error.mockReset();
@@ -149,7 +142,7 @@ describe('Property Validation', () => {
 
     expect(() => new Task({ logger: loggerMock }, { nested: 42 })).toThrow('Properties Validation failed');
     expect(loggerMock.error).toHaveBeenLastCalledWith(
-      'Validation for property "nested" failed:\n{"isArray":"nested must be an array"}\nvalue: 42',
+      'Validation for property "nested" failed:\n{"isArray":"nested must be an array","nestedValidation":"each value in nested property nested must be either object or array"}\nvalue: 42',
       { functionFqn: 'test' },
     );
     expect(() => new Task({ logger: loggerMock }, {})).toThrow('Properties Validation failed');


### PR DESCRIPTION
The RpcClient used to be initilaized lazyly. Since then the initilazation of the flow-app was made async and therefore the lazy initilaization is not needed anymore. 

This lazy init caused an error if multiple Flow-Functions tried to send an RPC Message at the same time for the first time.