### PR TITLE
feat(sdk): limit rpc msg size

### DIFF
--- a/.changeset/eight-chairs-obey.md
+++ b/.changeset/eight-chairs-obey.md
@@ -1,0 +1,5 @@
+---
+'@hahnpro/flow-sdk': minor
+---
+
+Added possibility to limit the max size of RPC messages via environment variable "MAX_RPC_MSG_SIZE_BYTES"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Flow SDK & CLI
 
-For release notes, see the [CHANGELOG](CHANGELOG.md)
+For release notes, see the [SDK CHANGELOG](packages/sdk/CHANGELOG.md) and [CLI CHANGELOG](packages/cli/CHANGELOG.md)
 
 ## Installing
 

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -117,7 +117,7 @@ After the definition of the Flow, it has to be instantiated. In the case of the 
 is done like the following:
 
 ```typescript
-const flowApp = new FlowApplication([ExampleModule, TestModule], flow, null, null, true);
+const flowApp = new FlowApplication([ExampleModule, TestModule], flow, { skipApi: true });
 ```
 
 The first argument of the constructor is an array of the modules that are used by the flow.
@@ -137,12 +137,11 @@ When using a Python script, a connection to a RabbitMQ broker is needed. When yo
 is set up like described [here](./development-environment.md), you can use the following snippet:
 
 ```typescript
-const amqpConnection = new AmqpConnection({ uri: 'amqp://localhost' });
-await amqpConnection.init();
+const amqpConfig = { hostname: 'localhost', port: 5672 };
+const flowApp = new FlowApplication([ExampleModule, TestModule], flow, { amqpConfig, skipApi: true });
 ```
 
-This will connect to the broker running locally. To use this pass `amqpConnection` instead of `null`
-as the second optional (fourth overall) argument to the constructor.
+The Flow Application will automatically try to establish an AMQP connection with the provided config.
 
 ### Definition of Function output checks
 
@@ -180,6 +179,6 @@ sent to the trigger, which then launches the execution of the Flow.
 flowApp.emit(new FlowEvent({ id: 'trigger' }, { foo: bar }));
 ```
 
-Here an event with the data `{ foo: bar }` is emitted to the Function with the id `trigger`.  
+Here an event with the data `{ foo: bar }` is emitted to the Function with the id `trigger`.
 There can be multiple statements like this, to test multiple iterations through the flow. This will
 likely require an adjustment to the listeners to handle more than one event.

--- a/examples/modules/python/src/python.spec.ts
+++ b/examples/modules/python/src/python.spec.ts
@@ -1,5 +1,5 @@
-import { AmqpConnection } from '@golevelup/nestjs-rabbitmq';
 import { FlowApplication, FlowEvent, TestModule } from '@hahnpro/flow-sdk';
+import { setTimeout } from 'timers/promises';
 
 import PythonModule from '../';
 
@@ -24,10 +24,8 @@ describe('Python', () => {
         deploymentId: 'testDeployment',
       },
     };
-    const amqpConnection = new AmqpConnection({ uri: 'amqp://localhost' });
-    await amqpConnection.init();
-    flowApp = new FlowApplication([PythonModule, TestModule], flow, null, amqpConnection, true);
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+    flowApp = new FlowApplication([PythonModule, TestModule], flow, { amqpConfig: {}, skipApi: true });
+    await setTimeout(2000);
   });
 
   test('rpc', (done) => {

--- a/examples/package.json
+++ b/examples/package.json
@@ -20,7 +20,6 @@
     "python-shell": "^3.0.1"
   },
   "devDependencies": {
-    "@golevelup/nestjs-rabbitmq": "^3.5.0",
     "@hahnpro/flow-cli": "workspace:*",
     "@nestjs/common": "^9.3.9",
     "@nestjs/core": "^9.3.9",

--- a/packages/sdk/lib/FlowElement.ts
+++ b/packages/sdk/lib/FlowElement.ts
@@ -119,7 +119,7 @@ export abstract class FlowElement<T = any> {
   protected interpolate = (value: any, ...templateVariables: any) => fillTemplate(value, ...templateVariables);
 
   protected async callRpcFunction(functionName: string, ...args: any[]) {
-    return this.app?.rpcClient().callFunction(this.rpcRoutingKey, functionName, ...args);
+    return this.app?.rpcClient.callFunction(this.rpcRoutingKey, functionName, ...args);
   }
 
   protected runPyRpcScript(scriptPath: string, ...args: (string | boolean | number)[]) {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@hahnpro/hpc-api": "workspace:*",
-    "amqp-connection-manager": "^3.9.0",
+    "amqp-connection-manager": "^4.1.11",
     "amqplib": "^0.10.3",
     "class-transformer": "0.5.1",
     "class-validator": "~0.14.0",
@@ -44,9 +44,6 @@
     "string-interp": "^0.3.6"
   },
   "devDependencies": {
-    "@golevelup/nestjs-rabbitmq": "^3.5.0",
-    "@nestjs/common": "^9.3.9",
-    "@types/amqp-connection-manager": "^2.0.12",
     "@types/amqplib": "^0.10.1",
     "@types/jest": "^29.4.2",
     "@types/lodash": "^4.14.191",

--- a/packages/sdk/test/context.spec.ts
+++ b/packages/sdk/test/context.spec.ts
@@ -19,7 +19,7 @@ describe('Flow Application', () => {
       },
       properties: { test: '123abcd' },
     };
-    const flowApp = new FlowApplication([TestModule], flow, loggerMock, null, true);
+    const flowApp = new FlowApplication([TestModule], flow, { logger: loggerMock, skipApi: true });
 
     let iteration = 0;
     flowApp.subscribe('testResource.default', {
@@ -100,7 +100,7 @@ describe('Flow Application', () => {
       context: { flowId: 'testFlow', deploymentId: 'testDeployment' },
       properties: { test: '123abcd' },
     };
-    const flowApp = new FlowApplication([TestModule], flow, loggerMock, null, true);
+    const flowApp = new FlowApplication([TestModule], flow, { logger: loggerMock, skipApi: true });
 
     let count = 0;
     flowApp.subscribe('testResource.default', {

--- a/packages/sdk/test/long-running-rpc.spec.ts
+++ b/packages/sdk/test/long-running-rpc.spec.ts
@@ -1,7 +1,7 @@
 import { FlowApplication, FlowEvent, FlowFunction, FlowModule, FlowResource, InputStream } from '../lib';
-import { AmqpConnection } from '@golevelup/nestjs-rabbitmq';
 import { join } from 'path';
 import { PythonShell } from 'python-shell';
+import { setTimeout } from 'timers/promises';
 
 describe('Flow RPC long running task', () => {
   let flowApp: FlowApplication;
@@ -15,10 +15,8 @@ describe('Flow RPC long running task', () => {
         deploymentId: 'testDeployment',
       },
     };
-    const amqpConnection = new AmqpConnection({ uri: 'amqp://localhost' });
-    await amqpConnection.init();
-    flowApp = new FlowApplication([TestModule], flow, null, amqpConnection, true);
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+    flowApp = new FlowApplication([TestModule], flow, { amqpConfig: {}, skipApi: true });
+    await setTimeout(2000);
   });
 
   test('FLOW.LRPC.1 rpc long running task', (done) => {

--- a/packages/sdk/test/message.spec.ts
+++ b/packages/sdk/test/message.spec.ts
@@ -16,7 +16,7 @@ describe('Flow SDK', () => {
         deploymentId: 'testDeployment',
       },
     };
-    const flowApp = new FlowApplication([TestModule], flow, null, null, true);
+    const flowApp = new FlowApplication([TestModule], flow, { skipApi: true });
 
     flowApp.subscribe('testResource.default', {
       next: (event1: FlowEvent) => {

--- a/packages/sdk/test/rpc.spec.ts
+++ b/packages/sdk/test/rpc.spec.ts
@@ -1,6 +1,6 @@
-import { AmqpConnection } from '@golevelup/nestjs-rabbitmq';
 import { join } from 'path';
 import { PythonShell } from 'python-shell';
+import { setTimeout } from 'timers/promises';
 
 import { FlowApplication, FlowEvent, FlowFunction, FlowModule, FlowResource, InputStream } from '../lib';
 
@@ -28,11 +28,9 @@ describe('Flow RPC', () => {
         deploymentId: 'testDeployment',
       },
     };
-    const amqpConnection = new AmqpConnection({ uri: 'amqp://localhost' });
-    await amqpConnection.init();
-    flowApp = new FlowApplication([TestModule], flow, null, amqpConnection, true, true);
+    flowApp = new FlowApplication([TestModule], flow, { amqpConfig: {}, skipApi: true, explicitInit: true });
     await flowApp.init();
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+    await setTimeout(2000);
   });
 
   test('FLOW.RPC.1 publish message', (done) => {

--- a/packages/sdk/test/rx.spec.ts
+++ b/packages/sdk/test/rx.spec.ts
@@ -20,7 +20,7 @@ describe('rx', () => {
         { id: 'testConnection3', source: 'testResource1', target: 'tap' },
       ],
     };
-    const flowApp = new FlowApplication([TestModule], flow, null, null, true);
+    const flowApp = new FlowApplication([TestModule], flow, { skipApi: true });
 
     flowApp.subscribe('tap.default', {
       next: (event: FlowEvent) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,6 @@ importers:
 
   examples:
     specifiers:
-      '@golevelup/nestjs-rabbitmq': ^3.5.0
       '@hahnpro/flow-cli': workspace:*
       '@hahnpro/flow-sdk': workspace:*
       '@nestjs/common': ^9.3.9
@@ -69,7 +68,6 @@ importers:
       class-validator: 0.14.0
       python-shell: 3.0.1
     devDependencies:
-      '@golevelup/nestjs-rabbitmq': 3.5.0_d56f3gzgbieq6fdcwcijmvtfvi
       '@hahnpro/flow-cli': link:../packages/cli
       '@nestjs/common': 9.3.9_ca43gjgfb2qovizjnmxfs634zy
       '@nestjs/core': 9.3.9_jrq2rdgfp2sx67wmylmrqliwxe
@@ -182,15 +180,12 @@ importers:
 
   packages/sdk:
     specifiers:
-      '@golevelup/nestjs-rabbitmq': ^3.5.0
       '@hahnpro/hpc-api': workspace:*
-      '@nestjs/common': ^9.3.9
-      '@types/amqp-connection-manager': ^2.0.12
       '@types/amqplib': ^0.10.1
       '@types/jest': ^29.4.2
       '@types/lodash': ^4.14.191
       '@types/node': ^18.15.3
-      amqp-connection-manager: ^3.9.0
+      amqp-connection-manager: ^4.1.11
       amqplib: ^0.10.3
       class-transformer: 0.5.1
       class-validator: ~0.14.0
@@ -206,7 +201,7 @@ importers:
       typescript: ^4.9.5
     dependencies:
       '@hahnpro/hpc-api': link:../api
-      amqp-connection-manager: 3.9.0_amqplib@0.10.3
+      amqp-connection-manager: 4.1.11_amqplib@0.10.3
       amqplib: 0.10.3
       class-transformer: 0.5.1
       class-validator: 0.14.0
@@ -218,9 +213,6 @@ importers:
       rxjs: 7.8.0
       string-interp: 0.3.6
     devDependencies:
-      '@golevelup/nestjs-rabbitmq': 3.5.0_d56f3gzgbieq6fdcwcijmvtfvi
-      '@nestjs/common': 9.3.9_welcnyot5bzd5wa2aovbkxpi4i
-      '@types/amqp-connection-manager': 2.0.12
       '@types/amqplib': 0.10.1
       '@types/jest': 29.4.2
       '@types/lodash': 4.14.191
@@ -817,43 +809,6 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@golevelup/nestjs-common/1.4.4:
-    resolution: {integrity: sha512-NTjtOhHTMuGwiR3lmBQKKaRr++mHQEsh8AxtaH+/EWOYKMK2Cv/8duaH9MQ0hI3TwnouyaA5IRxYR1ZCUyNXOQ==}
-    dependencies:
-      nanoid: 3.3.4
-    dev: true
-
-  /@golevelup/nestjs-discovery/3.0.0:
-    resolution: {integrity: sha512-ZvkXtobTKxXB1LJanP/l6Z/Fing88IMBr3uabQpU2IWjfsstjh02qYDSU2cfD6CSmNldX5ewW5Pd+SdK2lU8Sw==}
-    dependencies:
-      lodash: 4.17.21
-    dev: true
-
-  /@golevelup/nestjs-modules/0.6.1_d56f3gzgbieq6fdcwcijmvtfvi:
-    resolution: {integrity: sha512-E0STg8In8fhIivnGDJAA70+XLPHzK5bMTkCnif9FbZ8waTYDQ3T/QQL0h73k+CUFeznn1hmuEW14sNaE+8cd7w==}
-    peerDependencies:
-      '@nestjs/common': ^9.x
-      rxjs: ^7.x
-    dependencies:
-      '@nestjs/common': 9.3.9_welcnyot5bzd5wa2aovbkxpi4i
-      lodash: 4.17.21
-      rxjs: 7.8.0
-    dev: true
-
-  /@golevelup/nestjs-rabbitmq/3.5.0_d56f3gzgbieq6fdcwcijmvtfvi:
-    resolution: {integrity: sha512-8VtqgsQfbi+gIVJjOxMOoHKxwhRSEpuWIzMEHQMwURNeBac4Nl/u4HUo8CQovMIepfd1KsQeJI9HzglYim+59A==}
-    dependencies:
-      '@golevelup/nestjs-common': 1.4.4
-      '@golevelup/nestjs-discovery': 3.0.0
-      '@golevelup/nestjs-modules': 0.6.1_d56f3gzgbieq6fdcwcijmvtfvi
-      amqp-connection-manager: 3.9.0_amqplib@0.8.0
-      amqplib: 0.8.0
-    transitivePeerDependencies:
-      - '@nestjs/common'
-      - rxjs
-      - supports-color
-    dev: true
-
   /@humanwhocodes/config-array/0.11.8:
     resolution: {integrity: sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==}
     engines: {node: '>=10.10.0'}
@@ -1236,31 +1191,6 @@ packages:
       uid: 2.0.1
     dev: true
 
-  /@nestjs/common/9.3.9_welcnyot5bzd5wa2aovbkxpi4i:
-    resolution: {integrity: sha512-GshTD9Xz+wD2em6NyzU4NXw5IXMUmapgDgD+iuj6XL0258hvDwODmNk37mBBnZvTZlqER+krvIUKnS34etqF/A==}
-    peerDependencies:
-      cache-manager: <=5
-      class-transformer: '*'
-      class-validator: '*'
-      reflect-metadata: ^0.1.12
-      rxjs: ^7.1.0
-    peerDependenciesMeta:
-      cache-manager:
-        optional: true
-      class-transformer:
-        optional: true
-      class-validator:
-        optional: true
-    dependencies:
-      class-transformer: 0.5.1
-      class-validator: 0.14.0
-      iterare: 1.2.1
-      reflect-metadata: 0.1.13
-      rxjs: 7.8.0
-      tslib: 2.5.0
-      uid: 2.0.1
-    dev: true
-
   /@nestjs/core/9.3.9_jrq2rdgfp2sx67wmylmrqliwxe:
     resolution: {integrity: sha512-9g1A1G9eirLXEpH21rc6dKb08zHc2+adhCRz8NW39hbejcsxxD72FApJzt4QBQAKvu862ixt/tdpStnFT7lOSw==}
     requiresBuild: true
@@ -1352,12 +1282,6 @@ packages:
 
   /@tsconfig/node16/1.0.3:
     resolution: {integrity: sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==}
-
-  /@types/amqp-connection-manager/2.0.12:
-    resolution: {integrity: sha512-2GX1jG6ECpEXQF0X68gTTZc8MQ8GA0dM2mAd1irTpWlKzGKlGzCBtb1YnqLHozNNsoLtGI6UXSp0q06jU1LA6g==}
-    dependencies:
-      '@types/amqplib': 0.10.1
-    dev: true
 
   /@types/amqplib/0.10.1:
     resolution: {integrity: sha512-j6ANKT79ncUDnAs/+9r9eDujxbeJoTjoVu33gHHcaPfmLQaMhvfbH2GqSe8KUM444epAp1Vl3peVOQfZk3UIqA==}
@@ -1733,25 +1657,15 @@ packages:
       uri-js: 4.4.1
     dev: false
 
-  /amqp-connection-manager/3.9.0_amqplib@0.10.3:
-    resolution: {integrity: sha512-ZKw9ckJKz40Lc2pC7DY0NVocpzPalMaCgv0sBn+N4er2QFAJul9pIiMOm/FsPHeCzB+FulV7PckOpmZvWvewGQ==}
+  /amqp-connection-manager/4.1.11_amqplib@0.10.3:
+    resolution: {integrity: sha512-amk3oWAFglMdX5PKSjpkrp/uVBWaEp9CfwQ/6jMgoVQx0DdU7G0aM8X1VilZfOBPwBSbOwUYS1c2LCwjJcdN/Q==}
     engines: {node: '>=10.0.0', npm: '>5.0.0'}
     peerDependencies:
       amqplib: '*'
     dependencies:
       amqplib: 0.10.3
-      promise-breaker: 5.0.0
+      promise-breaker: 6.0.0
     dev: false
-
-  /amqp-connection-manager/3.9.0_amqplib@0.8.0:
-    resolution: {integrity: sha512-ZKw9ckJKz40Lc2pC7DY0NVocpzPalMaCgv0sBn+N4er2QFAJul9pIiMOm/FsPHeCzB+FulV7PckOpmZvWvewGQ==}
-    engines: {node: '>=10.0.0', npm: '>5.0.0'}
-    peerDependencies:
-      amqplib: '*'
-    dependencies:
-      amqplib: 0.8.0
-      promise-breaker: 5.0.0
-    dev: true
 
   /amqplib/0.10.3:
     resolution: {integrity: sha512-UHmuSa7n8vVW/a5HGh2nFPqAEr8+cD4dEZ6u9GjP91nHfr1a54RyAKyra7Sb5NH7NBKOUlyQSMXIp0qAixKexw==}
@@ -1764,20 +1678,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
-
-  /amqplib/0.8.0:
-    resolution: {integrity: sha512-icU+a4kkq4Y1PS4NNi+YPDMwdlbFcZ1EZTQT2nigW3fvOb6AOgUQ9+Mk4ue0Zu5cBg/XpDzB40oH10ysrk2dmA==}
-    engines: {node: '>=10'}
-    dependencies:
-      bitsyntax: 0.1.0
-      bluebird: 3.7.2
-      buffer-more-ints: 1.0.0
-      readable-stream: 1.1.14
-      safe-buffer: 5.2.1
-      url-parse: 1.5.10
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /ansi-colors/4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -2013,17 +1913,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /bitsyntax/0.1.0:
-    resolution: {integrity: sha512-ikAdCnrloKmFOugAfxWws89/fPc+nw0OOG1IzIE72uSOg/A3cYptKCjSUhDTuj7fhsJtzkzlv7l3b8PzRHLN0Q==}
-    engines: {node: '>=0.8'}
-    dependencies:
-      buffer-more-ints: 1.0.0
-      debug: 4.3.4
-      safe-buffer: 5.1.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /bl/4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
     dependencies:
@@ -2039,10 +1928,6 @@ packages:
       inherits: 2.0.4
       readable-stream: 3.6.1
     dev: false
-
-  /bluebird/3.7.2:
-    resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
-    dev: true
 
   /body-parser/1.20.1:
     resolution: {integrity: sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==}
@@ -2123,6 +2008,7 @@ packages:
 
   /buffer-more-ints/1.0.0:
     resolution: {integrity: sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==}
+    dev: false
 
   /buffer/5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -4625,12 +4511,6 @@ packages:
   /ms/2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  /nanoid/3.3.4:
-    resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-    dev: true
-
   /natural-compare-lite/1.4.0:
     resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
     dev: true
@@ -5055,8 +4935,9 @@ packages:
     engines: {node: '>= 0.6.0'}
     dev: false
 
-  /promise-breaker/5.0.0:
-    resolution: {integrity: sha512-mgsWQuG4kJ1dtO6e/QlNDLFtMkMzzecsC69aI5hlLEjGHFNpHrvGhFi4LiK5jg2SMQj74/diH+wZliL9LpGsyA==}
+  /promise-breaker/6.0.0:
+    resolution: {integrity: sha512-BthzO9yTPswGf7etOBiHCVuugs2N01/Q/94dIPls48z2zCmrnDptUUZzfIb+41xq0MnYZ/BzmOd6ikDR4ibNZA==}
+    dev: false
 
   /prompts/2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -5107,6 +4988,7 @@ packages:
 
   /querystringify/2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
+    dev: false
 
   /queue-microtask/1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -5180,6 +5062,7 @@ packages:
       inherits: 2.0.4
       isarray: 0.0.1
       string_decoder: 0.10.31
+    dev: false
 
   /readable-stream/2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
@@ -5265,6 +5148,7 @@ packages:
 
   /requires-port/1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+    dev: false
 
   /resolve-cwd/3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
@@ -5333,6 +5217,7 @@ packages:
 
   /safe-buffer/5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    dev: false
 
   /safe-regex-test/1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
@@ -5959,6 +5844,7 @@ packages:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
+    dev: false
 
   /util-deprecate/1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}


### PR DESCRIPTION
- add limit for max rpc message size (128MB)
- remove dependency on @golevelup/nestjs-rabbitmq (non-breaking) 
- fixes https://github.com/hahnprojects/hpc/issues/678 (non-breaking) 
- update amqp-connection-manager to v4
