### PR TITLE
feat(sdk): added Mock-API parameter to FlowApplication constructor

### DIFF
--- a/.changeset/fluffy-glasses-jog.md
+++ b/.changeset/fluffy-glasses-jog.md
@@ -1,0 +1,5 @@
+---
+'@hahnpro/flow-sdk': minor
+---
+
+Added a Mock-API parameter to the FlowApplication constructor. This enables simple use of the Mock-API in flow tests.

--- a/packages/sdk/test/flow.spec.ts
+++ b/packages/sdk/test/flow.spec.ts
@@ -2,7 +2,7 @@ import { Type } from 'class-transformer';
 import { IsArray, IsNumber, IsString, ValidateNested } from 'class-validator';
 import { setTimeout } from 'timers/promises';
 
-import { delay, FlowApplication, FlowEvent, FlowFunction, FlowModule, FlowResource, FlowTask, InputStream } from '../lib';
+import { delay, FlowApplication, FlowEvent, FlowFunction, FlowModule, FlowResource, FlowTask, InputStream, MockAPI } from '../lib';
 import { loggerMock } from './logger.mock';
 
 describe('Flow Application', () => {
@@ -303,6 +303,20 @@ describe('Flow Application', () => {
       },
     });
     flowApp.emit(new FlowEvent({ id: 'testTrigger' }, {}));
+  });
+
+  it('FLOW.FA.10 should take a Mock-API as a parameter', () => {
+    const flow = {
+      elements: [
+        { id: 'testTrigger', module: 'test-module', functionFqn: 'test.resource.TestResource' },
+        { id: 'testTask', module: 'test-module', functionFqn: 'test.task.TestTask' },
+      ],
+      connections: [{ id: 'testConnection', source: 'testTrigger', target: 'testTask' }],
+      context: { flowId: 'testFlow', deploymentId: 'testDeployment' },
+    };
+    const flowApp = new FlowApplication([TestModule], flow, { logger: loggerMock, skipApi: true, mockApi: new MockAPI({}) });
+
+    expect(flowApp.api).toBeInstanceOf(MockAPI);
   });
 });
 


### PR DESCRIPTION
Added a Mock-API parameter to the FlowApplication constructor. This re-enables use of the Mock-API in flow-tests. This (unintended) feature was removed when direct access to the `api` field was removed. 

This code can be replaced:
```javascript
const api = new MockAPI({});
flowApp = new FlowApplication([TestModule], flow, { skipApi: true, explicitInit: true });
await flowApp.init();
flowApp.api = api;
```
with:
```javascript
const api = new MockAPI({});
flowApp = new FlowApplication([TestModule], flow, { explicitInit: true, mockApi: api });
await flowApp.init();
```