### PR TITLE
fix(api): addition of ts values and events in mock api

### DIFF
--- a/.changeset/long-foxes-obey.md
+++ b/.changeset/long-foxes-obey.md
@@ -1,0 +1,5 @@
+---
+'@hahnpro/hpc-api': patch
+---
+
+fixed addition of timeseries values and events in mock api

--- a/packages/api/lib/mock/api.mock.ts
+++ b/packages/api/lib/mock/api.mock.ts
@@ -204,6 +204,7 @@ export class MockAPI implements API {
       cause: v.cause,
       level: v.level,
       group: v.group,
+      createdAt: v.createdAt,
     }));
 
     const timeseriesValues: TimeSeriesValue[][] = timeSeries.map((v) => v.values);

--- a/packages/api/lib/mock/timeseries.mock.service.ts
+++ b/packages/api/lib/mock/timeseries.mock.service.ts
@@ -64,7 +64,7 @@ export class TimeseriesMockService extends BaseService implements TimeSeriesServ
       };
       return this.addOne(dto);
     }
-    ts.data = [...ts.data, ...data];
+    ts.data = ts.data ? [...ts.data, ...data] : data;
     return Promise.resolve(ts);
   }
 


### PR DESCRIPTION
- fix addition of timeseries values to timeseries that were created through addOne in mock api
- add createdAt field to events in mock api -> needed in some tests