### PR TITLE
fix(api): update notification service interface

### DIFF
--- a/.changeset/eleven-doors-sparkle.md
+++ b/.changeset/eleven-doors-sparkle.md
@@ -1,5 +1,5 @@
 ---
-'@hahnpro/hpc-api': major
+'@hahnpro/hpc-api': patch
 ---
 
 add new property to notification service

--- a/.changeset/eleven-doors-sparkle.md
+++ b/.changeset/eleven-doors-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@hahnpro/hpc-api': major
+---
+
+add new property to notification service

--- a/packages/api/lib/notification.interface.ts
+++ b/packages/api/lib/notification.interface.ts
@@ -4,7 +4,9 @@ export interface Notification {
   id?: string;
   name: string;
   description: string;
-  userId: string;
+  userId?: string;
+  roleName?: string;
+  company?: string;
   read?: boolean;
   link: string;
   notificationType: NotificationType;

--- a/packages/api/lib/notification.service.ts
+++ b/packages/api/lib/notification.service.ts
@@ -6,7 +6,4 @@ export class NotificationService extends DataService<Notification> {
   constructor(httpClient: HttpClient) {
     super(httpClient, '/notifications');
   }
-  notifyUserByRole(notificationBody: Notification): Promise<Notification | Notification[]> {
-    return this.httpClient.post<Notification | Notification[]>(`${this.basePath}`, notificationBody);
-  }
 }

--- a/packages/api/lib/notification.service.ts
+++ b/packages/api/lib/notification.service.ts
@@ -6,4 +6,7 @@ export class NotificationService extends DataService<Notification> {
   constructor(httpClient: HttpClient) {
     super(httpClient, '/notifications');
   }
+  notifyUserByRole(notificationBody: Notification): Promise<Notification | Notification[]> {
+    return this.httpClient.post<Notification | Notification[]>(`${this.basePath}`, notificationBody);
+  }
 }


### PR DESCRIPTION
Extends the notification service on an endpoint, allowing users to be notified by role.

