### PR TITLE
fix(api): set build target to ES2015

### DIFF
--- a/.changeset/unlucky-pens-hide.md
+++ b/.changeset/unlucky-pens-hide.md
@@ -1,0 +1,5 @@
+---
+'@hahnpro/hpc-api': patch
+---
+
+Fixed build target to make api-package compatible with tools that use older language versions (i.e. cypress)

--- a/packages/api/lib/mock/api.mock.ts
+++ b/packages/api/lib/mock/api.mock.ts
@@ -135,7 +135,7 @@ export class MockAPI implements API {
       readWritePermissions: [],
       size: 0,
       fileId: '',
-      mimetype: v.mimetype || '',
+      mimetype: v.mimetype ?? '',
     }));
     const contentData: any[] = contents.map((v) => {
       return v.data ? v.data : readFileSync(join(v.filePath, v.filename));

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -4,6 +4,7 @@
     "baseUrl": ".",
     "outDir": "dist",
     "removeComments": false,
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "target": "ES2015"
   }
 }


### PR DESCRIPTION
This change is necessary as some tools, that this package may be used with, use older ES language versions. In particular Cypress can not handle the nullish coalescing (??) and optional chaining (.?) operators in the command file dependencies that are used here. 

The compiler target has been changed to ES2015 for the api-package. This version should be compatible with all tools and should have a negligible on the package otherwise.  