### PR TITLE
feat(api): extend filters of getManyFiltered() + improve mock api

### DIFF
--- a/.changeset/grumpy-apricots-kiss.md
+++ b/.changeset/grumpy-apricots-kiss.md
@@ -1,0 +1,5 @@
+---
+'@hahnpro/hpc-api': minor
+---
+
+extend filters of getManyFiltered() + improve mock api

--- a/packages/api/lib/asset.interface.ts
+++ b/packages/api/lib/asset.interface.ts
@@ -13,10 +13,10 @@ export interface AssetType {
   typeSchema: any;
   uiSchema: any;
   actions?: string[];
-  createdAt?: string;
-  updatedAt?: string;
   author?: string;
   revision?: number;
+  createdAt?: string;
+  updatedAt?: string;
   deletedAt?: string;
 }
 
@@ -41,6 +41,8 @@ export interface Asset {
   actions?: string[];
   author?: string;
   revision?: number;
+  createdAt?: string;
+  updatedAt?: string;
   deletedAt?: string;
 }
 

--- a/packages/api/lib/data.interface.ts
+++ b/packages/api/lib/data.interface.ts
@@ -15,11 +15,16 @@ export interface RequestParameter {
   sort?: string;
 }
 
-export interface Filter {
-  tags?: string[];
-  type?: string;
-  parent?: string;
+interface TimePeriod {
+  from: Date;
+  to: Date;
 }
+
+export function instanceOfTimePeriod(object: any): object is TimePeriod {
+  return 'from' in object && 'to' in object;
+}
+
+export type Filter = Record<string, string | string[] | TimePeriod>;
 
 export interface DataInterface<T> {
   addOne(dto: any): Promise<T>;

--- a/packages/api/lib/data.service.ts
+++ b/packages/api/lib/data.service.ts
@@ -21,6 +21,15 @@ export class DataService<T> extends APIBase implements DataInterface<T> {
     return this.httpClient.get<Paginated<T[]>>(`${this.basePath}`, { params });
   }
 
+  /**
+   * Filters the elements by the passed properties. The object with these properties has to be of the form:
+   * {
+   *   propertyName: string | string[] | { from: Date, to: Date },
+   *   ...
+   * }.
+   * @param filter The Object with the properties to filter by.
+   * @param params Other request parameters.
+   */
   public getManyFiltered(filter: Filter, params: RequestParameter = {}): Promise<Paginated<T[]>> {
     params.filter = this.getFilterString(filter);
     return this.getMany(params);

--- a/packages/api/lib/data.service.ts
+++ b/packages/api/lib/data.service.ts
@@ -1,5 +1,5 @@
 import { APIBase } from './api-base';
-import { DataInterface, Filter, Paginated, RequestParameter } from './data.interface';
+import { DataInterface, Filter, instanceOfTimePeriod, Paginated, RequestParameter } from './data.interface';
 
 export class DataService<T> extends APIBase implements DataInterface<T> {
   public addOne(dto: any): Promise<T> {
@@ -35,17 +35,15 @@ export class DataService<T> extends APIBase implements DataInterface<T> {
   }
 
   private getFilterString(filter: Filter) {
-    // tags%3D%40tag1%20tag2%3Btype%3D%3Dtype%3Bparent%3D%3D5a9d6c5182b56300015371c8
-    const { parent, tags, type } = filter;
     const filters: string[] = [];
-    if (tags) {
-      filters.push('tags=@' + tags.join());
-    }
-    if (type) {
-      filters.push('type==' + type);
-    }
-    if (parent) {
-      filters.push('parent==' + parent);
+    for (const [key, value] of Object.entries(filter)) {
+      if (instanceOfTimePeriod(value)) {
+        filters.push(`${key}>=${value.from.toISOString()};${key}<=${value.to.toISOString()}`);
+      } else if (Array.isArray(value)) {
+        filters.push(`${key}=@${value.join(',')}`);
+      } else {
+        filters.push(`${key}==${value}`);
+      }
     }
     return filters.join(';');
   }

--- a/packages/api/lib/mock/api.mock.ts
+++ b/packages/api/lib/mock/api.mock.ts
@@ -109,147 +109,124 @@ export class MockAPI implements API {
         return typeof v === 'string'
           ? v
           : {
-              name: v.name,
-              id: v.id,
-              readPermissions: [],
-              readWritePermissions: [],
-              typeSchema: {},
-              uiSchema: {},
+              ...v,
+              readPermissions: v.readPermissions || [],
+              readWritePermissions: v.readWritePermissions || [],
+              typeSchema: v.typeSchema ?? {},
+              uiSchema: v.uiSchema ?? {},
             };
       });
     const assets1: Asset[] = assets.map((v, index) => ({
       ...v,
-      readPermissions: [],
-      readWritePermissions: [],
+      readPermissions: v.readPermissions ?? [],
+      readWritePermissions: v.readWritePermissions ?? [],
       type: assetTypes[index],
     }));
     const assetRevisions1: AssetRevision[] = assetRevisions.map((v, index) => ({
       ...v,
-      readPermissions: [],
-      readWritePermissions: [],
+      readPermissions: v.readPermissions ?? [],
+      readWritePermissions: v.readWritePermissions ?? [],
       type: assetTypes[index],
     }));
     const contents1: Content[] = contents.map((v) => ({
       ...v,
-      readPermissions: [],
-      readWritePermissions: [],
-      size: 0,
-      fileId: '',
+      readPermissions: v.readPermissions ?? [],
+      readWritePermissions: v.readWritePermissions ?? [],
+      size: v.size ?? 0,
+      fileId: v.fileId ?? '',
       mimetype: v.mimetype ?? '',
     }));
-    const contentData: any[] = contents.map((v) => {
-      return v.data ? v.data : readFileSync(join(v.filePath, v.filename));
-    });
-    const secrets1: Secret[] = secrets.map((v) => ({ ...v, readPermissions: [], readWritePermissions: [] }));
-    const timeSeries1: TimeSeries[] = timeSeries.map((value) => ({
-      id: value.id,
-      name: value.name,
-      description: '',
-      readPermissions: [],
-      readWritePermissions: [],
-      assetRef: value.assetRef,
-      assetRef$name: value.assetRef$name,
-      assetTsId: value.assetTsId,
-      minDate: value.minDate,
-      maxBucketTimeRange: 0,
-      tsRef: value.tsRef,
-      autoDelData: new Date(),
-      autoDelBucket: new Date(),
+    const contentData: any[] = contents.map((v) => (v.data ? v.data : readFileSync(join(v.filePath, v.filename))));
+    const secrets1: Secret[] = secrets.map((v) => ({
+      ...v,
+      readPermissions: v.readPermissions ?? [],
+      readWritePermissions: v.readWritePermissions ?? [],
     }));
-    const endpoint1: Endpoint[] = endpoints.map((value) => ({
-      id: value.id,
-      name: value.name,
-      description: value.description,
-      status: value.status,
-      config: value.config,
-      notificationCheckInterval: value.notificationCheckInterval,
-      notificationPauseInterval: value.notificationPauseInterval,
-      nbOfNotificationsBetweenPauseInterval: value.nbOfNotificationsBetweenPauseInterval,
-      readPermissions: [],
-      readWritePermissions: [],
+    const timeSeries1: TimeSeries[] = timeSeries.map((v) => ({
+      ...v,
+      description: v.description ?? '',
+      readPermissions: v.readPermissions ?? [],
+      readWritePermissions: v.readWritePermissions ?? [],
+      maxBucketTimeRange: v.maxBucketTimeRange ?? 0,
+      maxDate: v.maxDate,
+      minDate: v.minDate,
+      autoDelData: v.autoDelData ?? new Date(),
+      autoDelBucket: v.autoDelBucket ?? new Date(),
+    }));
+    const timeSeriesValues: TimeSeriesValue[][] = timeSeries.map((v) => v.values);
+    const endpoint1: Endpoint[] = endpoints.map((v) => ({
+      ...v,
+      status: v.status,
+      config: v.config,
+      notificationCheckInterval: v.notificationCheckInterval,
+      notificationPauseInterval: v.notificationPauseInterval,
+      nbOfNotificationsBetweenPauseInterval: v.nbOfNotificationsBetweenPauseInterval,
+      readPermissions: v.readPermissions ?? [],
+      readWritePermissions: v.readWritePermissions ?? [],
     }));
     // TODO: ...
     const tasks1: Task[] = tasks.map((v) => ({
+      ...v,
       id: v.id,
-      name: v.name,
-      readPermissions: [],
-      readWritePermissions: [],
-      assetRef: v.assetRef,
-      subTasks: [],
-      assignedTo: v.assignedTo,
-      status: v.status,
-      acceptedBy: v.acceptedBy,
+      readPermissions: v.readPermissions ?? [],
+      readWritePermissions: v.readWritePermissions ?? [],
+      subTasks: v.subTasks ?? [],
     }));
-
     const events1: Event[] = events.map((v) => ({
-      id: v.id,
-      name: v.name,
-      readPermissions: [],
-      readWritePermissions: [],
-      assetRef: v.assetRef,
-      assetRef$name: v.assetRef$name,
-      alertRef: v.alertRef,
-      tsRef: v.tsRef,
-      tags: v.tags,
+      ...v,
+      readPermissions: v.readPermissions ?? [],
+      readWritePermissions: v.readWritePermissions ?? [],
       cause: v.cause,
       level: v.level,
-      group: v.group,
-      createdAt: v.createdAt,
     }));
-
-    const timeseriesValues: TimeSeriesValue[][] = timeSeries.map((v) => v.values);
-
     const diagrams1: FlowDiagram[] = diagrams.map((v) => ({
       ...v,
-      json: '',
+      json: v.json ?? '',
       author: 'nobody',
     }));
     const flows1: FlowDto[] = flows.map((v) => ({
       ...v,
-      readPermissions: [],
-      readWritePermissions: [],
+      readPermissions: v.readPermissions ?? [],
+      readWritePermissions: v.readWritePermissions ?? [],
       diagram: diagrams.find((v1) => v1.flow === v.id).id,
       name: `flow-${v.id}`,
-      deployments: [],
+      deployments: v.deployments ?? [],
     }));
     const flowRevisions1: FlowRevision[] = flowRevisions.map((v) => ({
       ...v,
-      readPermissions: [],
-      readWritePermissions: [],
+      readPermissions: v.readPermissions ?? [],
+      readWritePermissions: v.readWritePermissions ?? [],
       diagram: diagrams.find((v1) => v1.flow === v.originalId).id,
       name: `flow-${v.id}`,
-      deployments: [],
+      deployments: v.deployments ?? [],
     }));
-
     const deployments1: FlowDeployment[] = deployments.map((v) => ({
       ...v,
-      readPermissions: [],
-      readWritePermissions: [],
+      readPermissions: v.readPermissions ?? [],
+      readWritePermissions: v.readWritePermissions ?? [],
       diagram: v.diagram ?? '',
-      artifact: null,
-      flowModel: { connections: [], elements: [] },
+      artifact: v.artifact ?? null,
+      flowModel: v.flowModel ?? { connections: [], elements: [] },
       desiredStatus: 'running',
       actualStatus: 'generating queued',
       target: 'executor',
       name: `deployment-${v.id}`,
     }));
-
     const functions1: Array<FlowFunctionDto> = functions.map((v) => ({
       ...v,
       category: 'task',
-      readPermissions: [],
-      readWritePermissions: [],
+      readPermissions: v.readPermissions ?? [],
+      readWritePermissions: v.readWritePermissions ?? [],
       author: 'nobody',
     }));
     const functionRevisions1: Array<FlowFunctionRevision> = functionRevisions.map((v) => ({
       ...v,
       category: 'task',
-      readPermissions: [],
-      readWritePermissions: [],
+      readPermissions: v.readPermissions ?? [],
+      readWritePermissions: v.readWritePermissions ?? [],
       author: 'nobody',
     }));
-
-    const modules1: Replace<FlowModule, 'artifacts', Array<Artifact & { path: string }>>[] = modules.map((v, index) => ({
+    const modules1: ModuleInit[] = modules.map((v, index) => ({
       ...v,
       artifacts:
         modules[index].artifacts.map((art) => ({
@@ -261,28 +238,34 @@ export class MockAPI implements API {
           createdAt: '' + Date.now(),
         })) ?? [],
       author: 'nobody',
-      functions: [],
-      readPermissions: [],
-      readWritePermissions: [],
+      functions: v.functions ?? [],
+      readPermissions: v.readPermissions ?? [],
+      readWritePermissions: v.readWritePermissions ?? [],
     }));
-
-    const labels1: Label[] = labels.map((label) => ({
-      ...label,
-      color: '',
-      description: '',
-      readPermissions: [],
-      readWritePermissions: [],
+    const labels1: Label[] = labels.map((v) => ({
+      ...v,
+      color: v.color ?? '',
+      description: v.description ?? '',
+      readPermissions: v.readPermissions ?? [],
+      readWritePermissions: v.readWritePermissions ?? [],
     }));
-
-    const vaultSecrets1: VaultSecret[] = vault.map((v) => ({ ...v, readPermissions: [], readWritePermissions: [] }));
-
-    const notifications1: Notification[] = notifications.map((n) => ({ ...n, link: '', description: '', read: false }));
+    const vaultSecrets1: VaultSecret[] = vault.map((v) => ({
+      ...v,
+      readPermissions: v.readPermissions ?? [],
+      readWritePermissions: v.readWritePermissions ?? [],
+    }));
+    const notifications1: Notification[] = notifications.map((v) => ({
+      ...v,
+      link: v.link ?? '',
+      description: v.description ?? '',
+      read: v.read ?? false,
+    }));
 
     this.assets = new AssetMockService(this, assets1, assetRevisions1);
     this.contents = new ContentMockService(contents1, contentData);
     this.endpoints = new EndpointMockService(endpoint1);
     this.secrets = new SecretMockService(secrets1);
-    this.timeSeries = new TimeseriesMockService(timeSeries1, timeseriesValues);
+    this.timeSeries = new TimeseriesMockService(timeSeries1, timeSeriesValues);
     this.tasks = new TaskMockService(tasks1);
     this.events = new EventsMockService(events1);
     this.users = new UserMockService(users);
@@ -324,6 +307,7 @@ export type FlowDiagramInit = AtLeast<FlowDiagram, 'id' | 'flow'>;
 export type LabelInit = AtLeast<Label, 'id' | 'name'>;
 export type VaultSecretInit = AtLeast<VaultSecret, 'name' | 'secret'>;
 export type NotificationInit = AtLeast<Notification, 'id' | 'name' | 'userId' | 'notificationType'>;
+export type ModuleInit = Replace<FlowModule, 'artifacts', Array<Artifact & { path: string }>>;
 
 export interface UserInit {
   roles: string[];

--- a/packages/api/lib/mock/api.mock.ts
+++ b/packages/api/lib/mock/api.mock.ts
@@ -226,7 +226,7 @@ export class MockAPI implements API {
       readWritePermissions: v.readWritePermissions ?? [],
       author: 'nobody',
     }));
-    const modules1: ModuleInit[] = modules.map((v, index) => ({
+    const modules1: Replace<FlowModule, 'artifacts', Array<Artifact & { path: string }>>[] = modules.map((v, index) => ({
       ...v,
       artifacts:
         modules[index].artifacts.map((art) => ({
@@ -307,7 +307,6 @@ export type FlowDiagramInit = AtLeast<FlowDiagram, 'id' | 'flow'>;
 export type LabelInit = AtLeast<Label, 'id' | 'name'>;
 export type VaultSecretInit = AtLeast<VaultSecret, 'name' | 'secret'>;
 export type NotificationInit = AtLeast<Notification, 'id' | 'name' | 'userId' | 'notificationType'>;
-export type ModuleInit = Replace<FlowModule, 'artifacts', Array<Artifact & { path: string }>>;
 
 export interface UserInit {
   roles: string[];

--- a/packages/api/lib/mock/data.mock.service.ts
+++ b/packages/api/lib/mock/data.mock.service.ts
@@ -28,34 +28,53 @@ export class DataMockService<T> extends DataService<T> implements APIBaseMock<T>
 
   getMany(params?: RequestParameter): Promise<Paginated<T[]>> {
     const data = this.data;
+    if (params?.sort) {
+      this.sortData(data, params.sort);
+    }
     const page: Paginated<T[]> = {
       docs: data,
-      limit: params && params.limit ? params.limit : Number.MAX_SAFE_INTEGER,
+      limit: params?.limit ?? Number.MAX_SAFE_INTEGER,
       total: data.length,
     };
     return Promise.resolve(page);
   }
 
+  /**
+   * Filters the elements by the passed properties. The object with these properties has to be of the form:
+   * {
+   *   propertyName: string | string[] | { from: Date, to: Date },
+   *   ...
+   * }.
+   * @param filter The Object with the properties to filter by.
+   * @param params Other request parameters.
+   */
   async getManyFiltered(filter: Filter, params: RequestParameter = {}): Promise<Paginated<T[]>> {
     const paginated = await this.getMany(params);
     const newData = paginated.docs.filter((doc: any) =>
       Object.entries(filter).every(([filterKey, filterValue]): boolean => {
         const docValue = doc[filterKey];
+
         if (!docValue) {
           return false;
-        } else if (instanceOfTimePeriod(filterValue) && docValue) {
-          const date = new Date(docValue);
-          return date >= filterValue.from && date <= filterValue.to;
-        } else if (Array.isArray(filterValue)) {
-          return filterValue.includes(docValue);
-        } else {
-          return docValue === filterValue;
         }
+
+        return (
+          (typeof docValue === 'object' && (filterValue === docValue.name || filterValue === docValue.id)) || // data object
+          (typeof filterValue === 'object' &&
+            instanceOfTimePeriod(filterValue) &&
+            new Date(docValue) >= filterValue.from &&
+            new Date(docValue) <= filterValue.to) || // TimePeriod
+          (docValue instanceof Date && filterValue === docValue.toISOString()) || // Date
+          (Array.isArray(filterValue) && Array.isArray(docValue) && filterValue.some((fv) => docValue.includes(fv))) || // string[]
+          (Array.isArray(filterValue) && filterValue.includes(docValue)) ||
+          (Array.isArray(docValue) && docValue.includes(filterValue)) ||
+          docValue === filterValue // string
+        );
       }),
     );
     const page: Paginated<T[]> = {
       docs: newData,
-      limit: paginated.limit || Number.MAX_SAFE_INTEGER,
+      limit: paginated.limit ?? Number.MAX_SAFE_INTEGER,
       total: newData.length,
     };
     return Promise.resolve(page);
@@ -71,5 +90,20 @@ export class DataMockService<T> extends DataService<T> implements APIBaseMock<T>
     await this.deleteOne(id);
     const t = await this.addOne(dto);
     return Promise.resolve(t);
+  }
+
+  private sortData(data: T[], sort: string) {
+    const descending = sort.startsWith('-');
+    const sortString = descending ? sort.substring(1) : sort;
+    const compareFn = (a: any, b: any) => {
+      let aValue = a[sortString];
+      let bValue = b[sortString];
+      if (['updatedAt', 'createdAt', 'deletedAt'].includes(sortString)) {
+        aValue = new Date(a[sortString]).valueOf();
+        bValue = new Date(b[sortString]).valueOf();
+      }
+      return descending ? bValue - aValue : aValue - bValue;
+    };
+    data.sort(compareFn);
   }
 }

--- a/packages/api/lib/mock/data.mock.service.ts
+++ b/packages/api/lib/mock/data.mock.service.ts
@@ -43,8 +43,8 @@ export class DataMockService<T> extends DataService<T> implements APIBaseMock<T>
         const docValue = doc[filterKey];
         if (!docValue) {
           return false;
-        } else if (instanceOfTimePeriod(filterValue) && docValue[filterKey]) {
-          const date = new Date(docValue[filterKey]);
+        } else if (instanceOfTimePeriod(filterValue) && docValue) {
+          const date = new Date(docValue);
           return date >= filterValue.from && date <= filterValue.to;
         } else if (Array.isArray(filterValue)) {
           return filterValue.includes(docValue);

--- a/packages/api/lib/mock/timeseries.mock.service.ts
+++ b/packages/api/lib/mock/timeseries.mock.service.ts
@@ -56,6 +56,7 @@ export class TimeseriesMockService extends BaseService implements TimeSeriesServ
         description: '',
         maxBucketTimeRange: 0,
         minDate: undefined,
+        maxDate: undefined,
         name,
         readPermissions,
         readWritePermissions,

--- a/packages/api/lib/timeseries.interface.ts
+++ b/packages/api/lib/timeseries.interface.ts
@@ -7,6 +7,7 @@ export interface TimeSeries {
   assetRef?: string;
   assetRef$name?: string;
   assetTsId?: string;
+  maxDate: Date;
   minDate: Date;
   metrics?: string[];
   maxBucketTimeRange: number;

--- a/packages/api/test/helper.ts
+++ b/packages/api/test/helper.ts
@@ -1,4 +1,6 @@
-export async function testTrash(itemId, service) {
+import { Filter } from '../lib';
+
+export async function testTrash(itemId: string, service) {
   // test trash
   const deleted = await service.deleteOne(itemId);
   expect(deleted.id).toEqual(itemId);
@@ -25,4 +27,22 @@ export async function testTrash(itemId, service) {
   items = await service.getMany();
   expect(trash.docs.includes(deleted)).toBe(false);
   expect(items.docs.includes(deleted)).toBe(false);
+}
+
+/**
+ * Tests the getManyFiltered() function.
+ * @param filter The passed filter object.
+ * @param service The service to test.
+ * @param checkFor The property to check the received item for.
+ * @param expected The expected value of the property declared in checkFor.
+ */
+export async function testFilter(filter: Filter, service, checkFor: string, expected: string) {
+  const items = await service.getManyFiltered(filter);
+  expect(items).toBeDefined();
+  expect(Array.isArray(items.docs)).toBeTruthy();
+  expect(items.docs.length).toBeGreaterThan(0);
+
+  const item = items.docs[0];
+  expect(item).toBeDefined();
+  expect(item[checkFor]).toBe(expected);
 }


### PR DESCRIPTION
- extended filters of getManyFiltered() function to support any kind of parameter
- add option to pass more default values to mock api init
- add sorting to getMany() function in mock api

closes #202