### PR TITLE
fix(api): add type check to getFilterString function

### DIFF
--- a/.changeset/short-points-tease.md
+++ b/.changeset/short-points-tease.md
@@ -1,0 +1,5 @@
+---
+'@hahnpro/hpc-api': patch
+---
+
+add type check to getFilterString function

--- a/packages/api/lib/data.service.ts
+++ b/packages/api/lib/data.service.ts
@@ -46,7 +46,7 @@ export class DataService<T> extends APIBase implements DataInterface<T> {
   private getFilterString(filter: Filter) {
     const filters: string[] = [];
     for (const [key, value] of Object.entries(filter)) {
-      if (instanceOfTimePeriod(value)) {
+      if (typeof value === 'object' && instanceOfTimePeriod(value)) {
         filters.push(`${key}>=${value.from.toISOString()};${key}<=${value.to.toISOString()}`);
       } else if (Array.isArray(value)) {
         filters.push(`${key}=@${value.join(',')}`);


### PR DESCRIPTION
add type checking for object before checking the object instance -> created errors