### PR TITLE
feat(sdk): allow flow deployment to be run with owners permissions

### DIFF
--- a/.changeset/lucky-months-love.md
+++ b/.changeset/lucky-months-love.md
@@ -1,0 +1,6 @@
+---
+'@hahnpro/hpc-api': minor
+'@hahnpro/flow-sdk': minor
+---
+
+Allow Flow-Deployments to be run with owners permissions

--- a/packages/api/lib/api.ts
+++ b/packages/api/lib/api.ts
@@ -36,7 +36,10 @@ export class API {
   public vault: VaultService;
   public notifications: NotificationService;
 
-  constructor(public readonly httpClient?: HttpClient) {
+  constructor(
+    public readonly httpClient?: HttpClient,
+    context?: { tokenSubject?: string },
+  ) {
     if (!httpClient) {
       // remove leading and trailing slashes
       const normalizePath = (value = '', defaultValue = '') => value.replace(/(?:^\/+)|(?:\/+$)/g, '') || defaultValue;
@@ -56,8 +59,7 @@ export class API {
       if (!secret) {
         throw new Error('"API_BASE_URL", "API_USER", "AUTH_REALM" and "AUTH_SECRET" environment variables must be set');
       }
-
-      this.httpClient = new HttpClient(apiUrl, authUrl, realm, client, secret);
+      this.httpClient = new HttpClient(apiUrl, authUrl, realm, client, secret, context?.tokenSubject);
     }
 
     this.assets = new AssetService(this.httpClient);

--- a/packages/api/lib/resource.interface.ts
+++ b/packages/api/lib/resource.interface.ts
@@ -6,6 +6,7 @@ export interface ResourceReference {
 
 export interface Resource {
   id: string;
+  owner?: Owner;
   name: string;
   readPermissions: string[];
   readWritePermissions: string[];
@@ -17,4 +18,18 @@ export interface Resource {
   updatedAt?: string | Date;
   deletedAt?: string | Date;
   revision?: string;
+  createdBy?: Author;
+  updatedBy?: Author;
+}
+
+export interface Author {
+  id: string;
+  username: string;
+  impersonatorId?: string;
+  impersonatorUsername?: string;
+}
+
+export interface Owner {
+  id: string;
+  type: 'org' | 'user';
 }

--- a/packages/api/test/http.service.spec.ts
+++ b/packages/api/test/http.service.spec.ts
@@ -130,4 +130,23 @@ describe('HTTP Service', () => {
     await client.get<any>('/assets');
     expect(axiosMock.history.post.length).toBe(3);
   });
+
+  it('FLOW.HS.10 should exchange token', async () => {
+    axiosMock
+      .onPost('/realms/test/protocol/openid-connect/token')
+      .replyOnce(200, {
+        access_token: 'TOKEN',
+        expires_in: '123456',
+      })
+      .onPost('/realms/test/protocol/openid-connect/token')
+      .replyOnce(200, {
+        access_token: 'EXCHANGED_TOKEN',
+        expires_in: '123456',
+      });
+
+    axiosMock.onGet('/api/assets').abortRequest();
+    const client = new HttpClient('/api', 'https://test.com', 'test', 'test-client', 'test-secret', 'test-user');
+    const token = await client.getAccessToken();
+    expect(token).toBe('EXCHANGED_TOKEN');
+  });
 });

--- a/packages/sdk/lib/FlowApplication.ts
+++ b/packages/sdk/lib/FlowApplication.ts
@@ -151,7 +151,12 @@ export class FlowApplication {
     try {
       if (!this.skipApi && !(this._api instanceof MockAPI)) {
         // only create real API if it should not be skipped and is not already a mock
-        this._api = new API(this.apiClient);
+        let tokenSubject: string;
+        const { owner, runAsOwner } = this.context;
+        if (runAsOwner && owner) {
+          tokenSubject = owner.type === 'org' ? 'org-admin-' + owner.id : owner.id;
+        }
+        this._api = new API(this.apiClient, { tokenSubject });
       }
     } catch (err) {
       this.logger.error(err?.message || err);

--- a/packages/sdk/lib/flow.interface.ts
+++ b/packages/sdk/lib/flow.interface.ts
@@ -1,7 +1,11 @@
+import { Owner } from '@hahnpro/hpc-api';
+
 export interface FlowContext {
   deploymentId?: string;
   diagramId?: string;
   flowId?: string;
+  owner?: Owner;
+  runAsOwner?: boolean;
 }
 
 export interface FlowElementContext extends FlowContext {


### PR DESCRIPTION
Allow Flow-Deployments to be run with owners permissions

runAsOwner flag is optional for now but will be the default in a future version

Preperation for https://github.com/hahnprojects/hpc/issues/1002