### PR TITLE
fix: fixed missing context manager when testing standalone element

### DIFF
--- a/.changeset/young-buttons-hang.md
+++ b/.changeset/young-buttons-hang.md
@@ -1,0 +1,5 @@
+---
+'@hahnpro/flow-sdk': patch
+---
+
+Fixed test failures when testing an element outside of a flowapplication

--- a/packages/sdk/lib/FlowElement.ts
+++ b/packages/sdk/lib/FlowElement.ts
@@ -70,7 +70,7 @@ export abstract class FlowElement<T = any> {
   public replacePlaceholderAndSetProperties() {
     const placeholderProperties = this.propertiesWithPlaceholders;
     if (this.propertiesWithPlaceholders) {
-      this.setProperties(this.app.getContextManager()?.replaceAllPlaceholderProperties(placeholderProperties));
+      this.setProperties(this.app.getContextManager?.()?.replaceAllPlaceholderProperties(placeholderProperties));
     }
   }
 
@@ -147,7 +147,7 @@ export abstract class FlowElement<T = any> {
   }
 
   protected interpolate = (value: any, ...templateVariables: any) =>
-    fillTemplate(value, ...templateVariables, { flow: this.app?.getContextManager().getProperties().flow ?? {} });
+    fillTemplate(value, ...templateVariables, { flow: this.app?.getContextManager?.().getProperties?.().flow ?? {} });
 
   protected async callRpcFunction(functionName: string, ...args: any[]) {
     return this.app?.rpcClient.callFunction(this.rpcRoutingKey, functionName, ...args);

--- a/packages/sdk/test/context.spec.ts
+++ b/packages/sdk/test/context.spec.ts
@@ -127,6 +127,23 @@ describe('Flow Application', () => {
     expect(loggerMock.verbose).toHaveBeenCalledTimes(1);
     expect(loggerMock.verbose).toHaveBeenCalledWith('test', expect.objectContaining({ truncate: false }));
   });
+
+  test('Flow.CON.5 creation of element without app', () => {
+    const elem = new TestResource(
+      {
+        id: 'testResource',
+        logger: loggerMock,
+        app: {
+          emit: jest.fn(),
+          emitPartial: jest.fn(),
+        },
+      },
+      { assetId: '1234' },
+    );
+
+    elem.onDefault(new FlowEvent({ id: 'tr' }, { test: 'tyz' }));
+    expect(loggerMock.verbose).toHaveBeenCalledTimes(1);
+  });
 });
 
 @FlowFunction('test.resource.TestResource')

--- a/packages/sdk/test/context.spec.ts
+++ b/packages/sdk/test/context.spec.ts
@@ -142,7 +142,7 @@ describe('Flow Application', () => {
     );
 
     elem.onDefault(new FlowEvent({ id: 'tr' }, { test: 'tyz' }));
-    expect(loggerMock.verbose).toHaveBeenCalledTimes(1);
+    expect(loggerMock.verbose).toHaveBeenCalledTimes(2);
   });
 });
 


### PR DESCRIPTION
fixed bug that caused test failures when testing a `FlowElement` outside of a `FlowApplication`.