### PR TITLE
fix: added missing asset-type-service to Mock-API

### DIFF
--- a/.changeset/shy-dragons-occur.md
+++ b/.changeset/shy-dragons-occur.md
@@ -1,0 +1,5 @@
+---
+'@hahnpro/hpc-api': patch
+---
+
+added missing asset-type-service init to Mock-API

--- a/packages/api/lib/mock/api.mock.ts
+++ b/packages/api/lib/mock/api.mock.ts
@@ -262,6 +262,7 @@ export class MockAPI implements API {
     }));
 
     this.assets = new AssetMockService(this, assets1, assetRevisions1);
+    this.assetTypes = new AssetTypesMockService(assetTypes, []);
     this.contents = new ContentMockService(contents1, contentData);
     this.endpoints = new EndpointMockService(endpoint1);
     this.secrets = new SecretMockService(secrets1);

--- a/packages/api/lib/mock/assetTypes.mock.service.ts
+++ b/packages/api/lib/mock/assetTypes.mock.service.ts
@@ -14,10 +14,18 @@ class BaseService extends APIBaseMock<AssetType> {}
 
 export class AssetTypesMockService extends BaseService implements AssetTypesService {
   constructor(
-    assetTypes: AssetType[],
+    assetTypes: Array<AssetType | string>,
     private revisions: AssetTypeRevision[],
   ) {
-    super(assetTypes);
+    const defaultTyp: AssetType = {
+      name: 'defaultType',
+      readPermissions: [],
+      readWritePermissions: [],
+      typeSchema: { type: 'object' },
+      uiSchema: {},
+    };
+    const types = assetTypes.map((type) => (typeof type === 'string' ? { id: type, ...defaultTyp } : type));
+    super(types);
   }
 
   getMany(params?: RequestParameter): Promise<Paginated<AssetType[]>> {

--- a/packages/api/test/api.mock.spec.ts
+++ b/packages/api/test/api.mock.spec.ts
@@ -20,6 +20,7 @@ describe('Mock-API test', () => {
         updatedAt: new Date(timestamp).toISOString(),
       },
       { id: 'asset2', name: 'deleteAsset', type: { id: 'testId', name: 'testType' } },
+      { id: 'assetNoType', name: 'deleteAsset', type: '12345678' },
     ],
     assetRevisions: [{ id: 'assetRevision1', originalId: 'asset1', name: 'testAssetRevision', type: { id: 'testId', name: 'testType' } }],
     contents: [
@@ -538,6 +539,7 @@ describe('Mock-API test', () => {
     const count = await api.labels.count();
     expect(count).toBeGreaterThan(0);
   });
+
   test('FLOW.API.MOCK.14 vault', async () => {
     const vaultSecrets = await api.vault.getMany().catch((err) => logError(err));
     expect(vaultSecrets).toBeDefined();
@@ -567,6 +569,13 @@ describe('Mock-API test', () => {
       expect((notification as any).read).toBe(false);
     }
   }, 60000);
+
+  test('FLOW.API.MOCK.16 assettypes', async () => {
+    const types = await api.assetTypes.getMany();
+
+    expect(types.docs.length).toBe(3);
+    expect(types.docs[2].name).toBe('defaultType');
+  });
 });
 
 function logError(err: any) {


### PR DESCRIPTION
The Mock-API was missing the init for the asset-type service. 

This caused code like this to fail in the context of the Mock-API:

```typescript
const type = await api.assetTypes.addOne({...});
```